### PR TITLE
Hit feat/hit 113 add some config params to the geospatial question

### DIFF
--- a/libs/shared/src/lib/survey/components/geospatial.ts
+++ b/libs/shared/src/lib/survey/components/geospatial.ts
@@ -6,6 +6,7 @@ import {
   ALL_FIELDS,
   GeofieldsListboxComponent,
 } from '../../components/geofields-listbox/geofields-listbox.component';
+import { BASEMAPS } from '../../components/ui/map/const/baseMaps';
 
 /**
  * Extract geofields from question ( to match with latest version of the available ones )
@@ -70,6 +71,48 @@ export const init = (Survey: any, domService: DomService): void => {
         // dependsOn: ['geometry'],
         // visibleIf: (obj: null | any) => !!obj && obj.geometry === 'POINT',
       });
+
+      // Base map
+      serializer.addProperty('geospatial', {
+        name: 'BaseMap',
+        type: 'dropdown',
+        category: 'Map Properties',
+        visibleIndex: 3,
+        default: 'streets',
+        choices: BASEMAPS,
+      });
+
+      // Default zoom
+      serializer.addProperty('geospatial', {
+        name: 'DefaultZoom',
+        type: 'number',
+        category: 'Map Properties',
+        visibleIndex: 4,
+        default: 0,
+      });
+
+      // Latitude
+      serializer.addProperty('geospatial', {
+        name: 'Latitude',
+        type: 'number',
+        minValue: -90,
+        maxValue: 90,
+        category: 'Map Properties',
+        visibleIndex: 5,
+        default: 0,
+      });
+
+      // Longitude
+      serializer.addProperty('geospatial', {
+        name: 'Longitude',
+        type: 'number',
+        category: 'Map Properties',
+        minValue: -180,
+        maxValue: 180,
+        visibleIndex: 6,
+        default: 0,
+      });
+
       // Tagbox
       const listBoxEditor = {
         render: (editor: any, htmlElement: HTMLElement) => {
@@ -105,9 +148,45 @@ export const init = (Survey: any, domService: DomService): void => {
       // Set geo fields
       instance.fields = getGeoFields(question);
 
+      // Set base map
+      instance.mapSettings.basemap = question.BaseMap;
+
+      // Set default zoom
+      instance.mapSettings.initialState = {
+        viewpoint: {
+          center: {
+            latitude: question.Latitude,
+            longitude: question.Longitude,
+          },
+          zoom: question.DefaultZoom,
+        },
+      };
+
       // Listen to change on geofields
       question.registerFunctionOnPropertyValueChanged('geoFields', () => {
         instance.fields = question.geoFields;
+      });
+
+      // Listen to change on base map
+      question.registerFunctionOnPropertyValueChanged('BaseMap', () => {
+        instance.mapSettings.basemap = question.BaseMap;
+      });
+
+      // Listen to change on default zoom
+      question.registerFunctionOnPropertyValueChanged('DefaultZoom', () => {
+        instance.mapSettings.initialState.viewpoint.zoom = question.DefaultZoom;
+      });
+
+      // Listen to change on latitude
+      question.registerFunctionOnPropertyValueChanged('Latitude', () => {
+        instance.mapSettings.initialState.viewpoint.center.latitude =
+          question.Latitude;
+      });
+
+      // Listen to change on longitude
+      question.registerFunctionOnPropertyValueChanged('Longitude', () => {
+        instance.mapSettings.initialState.viewpoint.center.longitude =
+          question.Longitude;
       });
 
       // updates the question value when the map changes

--- a/libs/shared/src/lib/survey/components/geospatial.ts
+++ b/libs/shared/src/lib/survey/components/geospatial.ts
@@ -169,24 +169,60 @@ export const init = (Survey: any, domService: DomService): void => {
 
       // Listen to change on base map
       question.registerFunctionOnPropertyValueChanged('BaseMap', () => {
-        instance.mapSettings.basemap = question.BaseMap;
+        instance.mapSettings = {
+          ...instance.mapSettings,
+          basemap: question.BaseMap,
+        };
       });
 
       // Listen to change on default zoom
       question.registerFunctionOnPropertyValueChanged('DefaultZoom', () => {
-        instance.mapSettings.initialState.viewpoint.zoom = question.DefaultZoom;
+        instance.mapSettings = {
+          ...instance.mapSettings,
+          initialState: {
+            ...instance.mapSettings.initialState,
+            viewpoint: {
+              ...instance.mapSettings.initialState.viewpoint,
+              zoom: question.DefaultZoom,
+            },
+          },
+        };
       });
 
       // Listen to change on latitude
       question.registerFunctionOnPropertyValueChanged('Latitude', () => {
-        instance.mapSettings.initialState.viewpoint.center.latitude =
-          question.Latitude;
+        const viewpoint = {
+          ...instance.mapSettings.initialState.viewpoint,
+          center: {
+            ...instance.mapSettings.initialState.viewpoint.center,
+            latitude: question.Latitude,
+          },
+        };
+        instance.mapSettings = {
+          ...instance.mapSettings,
+          initialState: {
+            ...instance.mapSettings.initialState,
+            viewpoint,
+          },
+        };
       });
 
       // Listen to change on longitude
       question.registerFunctionOnPropertyValueChanged('Longitude', () => {
-        instance.mapSettings.initialState.viewpoint.center.longitude =
-          question.Longitude;
+        const viewpoint = {
+          ...instance.mapSettings.initialState.viewpoint,
+          center: {
+            ...instance.mapSettings.initialState.viewpoint.center,
+            longitude: question.Longitude,
+          },
+        };
+        instance.mapSettings = {
+          ...instance.mapSettings,
+          initialState: {
+            ...instance.mapSettings.initialState,
+            viewpoint,
+          },
+        };
       });
 
       // updates the question value when the map changes


### PR DESCRIPTION
# Description

For the geospatial question, added option to set default basemap, zoom and center position like we can in the map widget.
(I don't found way to update map while setting new default values)

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-113

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Setting the default of basemap, zoom and center position and seeing if the map changes to the new default value.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/24783896/7479a94c-f231-4972-8497-c3d9105a4e1b

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
