### PR TITLE
fixed a bug where tooltip would never appear on widgets in front-office

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
@@ -98,7 +98,7 @@
 <ng-template #defaultTemplate>
   <!-- Widget tooltip -->
   <ui-button
-    *ngIf="widget.settings?.widgetDisplay?.showTooltip && collapsed"
+    *ngIf="widget.settings?.widgetDisplay?.showTooltip"
     [isIcon]="true"
     icon="info"
     variant="grey"

--- a/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
@@ -96,21 +96,23 @@
 </ng-container>
 
 <ng-template #defaultTemplate>
-  <!-- Widget tooltip -->
-  <ui-button
-    *ngIf="widget.settings?.widgetDisplay?.showTooltip"
-    [isIcon]="true"
-    icon="info"
-    variant="grey"
-    [uiTooltip]="widget.settings.widgetDisplay.tooltip"
-  ></ui-button>
-  <!-- Expand widget -->
-  <ui-button
-    *ngIf="!(widget.component === 'map')"
-    [isIcon]="true"
-    icon="open_in_full"
-    [uiTooltip]="'components.widget.expand' | translate"
-    (click)="onClick('expand')"
-    variant="grey"
-  ></ui-button>
+  <div class="flex gap-1">
+    <!-- Widget tooltip -->
+    <ui-button
+      *ngIf="widget.settings?.widgetDisplay?.showTooltip"
+      [isIcon]="true"
+      icon="info"
+      variant="grey"
+      [uiTooltip]="widget.settings.widgetDisplay.tooltip"
+    ></ui-button>
+    <!-- Expand widget -->
+    <ui-button
+      *ngIf="!(widget.component === 'map')"
+      [isIcon]="true"
+      icon="open_in_full"
+      [uiTooltip]="'components.widget.expand' | translate"
+      (click)="onClick('expand')"
+      variant="grey"
+    ></ui-button>
+  </div>
 </ng-template>


### PR DESCRIPTION
# Description

Creating a widget (grid, summary card, graph, etc.) and setting a tooltip for it would work only in the back-office because in the front-office the widget template falls back to defaultTemplate and this template has a "collapsed" condition which doesn't work and seems to be unnecessary since the expand button doesn't even show up on widgets with a tooltip set (in front-office).

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-175
- Original pr: https://github.com/ReliefApplications/ems-frontend/pull/2065

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Create a widget, set a tooltip for it and navigate to front-office. If a tooltip is set, it should show up. If not, the expand button should instead for all widgets but maps.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/39497117/12cebeec-543d-49a1-bb16-0c7df85892a3)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
