### PR TITLE
feat/HIT-164_Add-ability-to-filter-by-current-user-on-aggregations

### DIFF
--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -6,13 +6,13 @@ import {
   OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   // SimpleChanges,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
-import { clone, get } from 'lodash';
-// import { clone, get, isEqual } from 'lodash';
+import { clone, get, isEqual } from 'lodash';
 import { takeUntil } from 'rxjs/operators';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { FIELD_TYPES, FILTER_OPERATORS } from '../filter.const';
@@ -111,12 +111,12 @@ export class FilterRowComponent
     }
   }
 
-  ngOnChanges(/*changes: SimpleChanges*/): void {
+  ngOnChanges(changes: SimpleChanges): void {
     const initialField = this.form.get('field')?.value;
     if (
       initialField &&
-      this.fields.length > 0 /*&&
-      !isEqual(changes.fields?.previousValue, changes.fields?.currentValue)*/
+      this.fields.length > 0 &&
+      !isEqual(changes.fields?.previousValue, changes.fields?.currentValue)
     ) {
       this.setField(initialField);
     }
@@ -142,10 +142,6 @@ export class FilterRowComponent
       fields = clone(field.fields);
     }
 
-    if (!field.editor) {
-      field.editor = this.getEditorFromType(field.type.name);
-    }
-
     if (field) {
       this.field = field;
       const type = {
@@ -169,42 +165,6 @@ export class FilterRowComponent
       }
       // set operator template
       this.setEditor(this.field);
-    }
-  }
-
-  /**
-   * Get editor from type.
-   *
-   * @param type field type
-   *
-   * @returns editor
-   */
-  private getEditorFromType(type: string): string {
-    switch (type) {
-      case 'String':
-        return 'text';
-      case 'Text':
-        return 'text';
-      case 'Time':
-        return 'time';
-      case 'Date':
-        return 'date';
-      case 'DateTime':
-        return 'datetime';
-      case 'Boolean':
-        return 'boolean';
-      case 'Float':
-        return 'numeric';
-      case 'Number':
-        return 'numeric';
-      case 'Decimal':
-        return 'numeric';
-      case 'Integer':
-        return 'numeric';
-      case 'Enum':
-        return 'select';
-      default:
-        return 'text';
     }
   }
 

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -141,6 +141,11 @@ export class FilterRowComponent
       field = fields.find((x) => x.name === fragment);
       fields = clone(field.fields);
     }
+
+    if (!field.editor) {
+      field.editor = this.getEditorFromType(field.type.name);
+    }
+
     if (field) {
       this.field = field;
       const type = {
@@ -164,6 +169,35 @@ export class FilterRowComponent
       }
       // set operator template
       this.setEditor(this.field);
+    }
+  }
+
+  private getEditorFromType(type: string): string {
+    switch (type) {
+      case 'String':
+        return 'text';
+      case 'Text':
+        return 'text';
+      case 'Time':
+        return 'time';
+      case 'Date':
+        return 'date';
+      case 'DateTime':
+        return 'datetime';
+      case 'Boolean':
+        return 'boolean';
+      case 'Float':
+        return 'numeric';
+      case 'Number':
+        return 'numeric';
+      case 'Decimal':
+        return 'numeric';
+      case 'Integer':
+        return 'numeric';
+      case 'Enum':
+        return 'select';
+      default:
+        return 'text';
     }
   }
 

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -172,6 +172,13 @@ export class FilterRowComponent
     }
   }
 
+  /**
+   * Get editor from type.
+   *
+   * @param type field type
+   *
+   * @returns editor
+   */
   private getEditorFromType(type: string): string {
     switch (type) {
       case 'String':

--- a/libs/shared/src/lib/components/ui/aggregation-builder/graphql/queries.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/graphql/queries.ts
@@ -145,3 +145,29 @@ export const GET_QUERY_TYPES = gql`
     }
   }
 `;
+
+/** Graphql query to get metadata from fields */
+export const GET_FIELDS_METADATA = gql`
+  query GetFieldsMetadata($resource: ID!) {
+    resource(id: $resource) {
+      name
+      metadata {
+        name
+        type
+        editor
+        filter
+        multiSelect
+        options
+        fields {
+          name
+          type
+          editor
+          filter
+          multiSelect
+          options
+        }
+        usedIn
+      }
+    }
+  }
+`;

--- a/libs/shared/src/lib/survey/functions/getPrescriptionInfo.ts
+++ b/libs/shared/src/lib/survey/functions/getPrescriptionInfo.ts
@@ -31,7 +31,7 @@ function getPrescriptionInfo(this: { survey: SurveyModel }, params: any[]) {
     header_text: 'Remplir la prescription',
   };
 
-  if (typeof prescription !== 'object') {
+  if (typeof prescription !== 'object' || !prescription) {
     return DEFAULT_INFO;
   }
 


### PR DESCRIPTION
# Description

Add ability to show operator of 'filter by' on aggregations. That’s already possible in the layouts, but in the aggregations the operators don’t show. After this pr, it will.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-164

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Selecting fields in filter on aggregations and check if it shows the operator.

## Screenshots


https://github.com/ReliefApplications/oort-frontend/assets/24783896/d6938a95-3a51-4d0d-8909-bcb25df890d8



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
