### PR TITLE
HIT-181-add-real-time-visualization-to-aggregation-builder

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -481,6 +481,10 @@
 				"week": "Week",
 				"year": "Year"
 			},
+			"preview": {
+				"hide": "Hide preview",
+				"show": "Show preview"
+			},
 			"sourceFields": "Select fields",
 			"stages": {
 				"addFields": "Add fields",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -481,6 +481,10 @@
 				"week": "Semaine",
 				"year": "Année"
 			},
+			"preview": {
+				"hide": "Masquer l'aperçu",
+				"show": "Afficher l'aperçu"
+			},
 			"sourceFields": "Sélectionner les champs",
 			"stages": {
 				"addFields": "Ajouter des champs",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -481,6 +481,10 @@
 				"week": "******",
 				"year": "******"
 			},
+			"preview": {
+				"hide": "******",
+				"show": "******"
+			},
 			"sourceFields": "******",
 			"stages": {
 				"addFields": "******",

--- a/libs/shared/src/lib/components/aggregation/edit-aggregation-modal/edit-aggregation-modal.component.html
+++ b/libs/shared/src/lib/components/aggregation/edit-aggregation-modal/edit-aggregation-modal.component.html
@@ -5,7 +5,7 @@
     </h3>
   </ng-container>
   <ng-container ngProjectAs="content">
-    <form [formGroup]="formGroup" class="flex flex-col gap-8">
+    <form [formGroup]="formGroup" class="flex flex-col gap-8 h-full">
       <div class="flex flex-col">
         <div uiFormFieldDirective>
           <label>{{ 'common.name' | translate }}</label>
@@ -20,8 +20,9 @@
           </ui-select-menu>
         </div>
       </div>
-      <div class="flex flex-col">
+      <div class="flex flex-col h-full">
         <shared-aggregation-builder
+          class="h-full"
           [resource]="resource"
           [aggregationForm]="formGroup"
         ></shared-aggregation-builder>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
@@ -59,12 +59,14 @@ export const addStage = (value: any) => {
     case PipelineStage.FILTER: {
       return formBuilder.group({
         type: [PipelineStage.FILTER],
+        preview: true,
         form: createFilterGroup(get(value, 'form', {})),
       });
     }
     case PipelineStage.SORT: {
       return formBuilder.group({
         type: [PipelineStage.SORT],
+        preview: true,
         form: formBuilder.group({
           field: [get(value, 'form.field', ''), Validators.required],
           order: [get(value, 'form.order', 'asc'), Validators.required],
@@ -74,6 +76,7 @@ export const addStage = (value: any) => {
     case PipelineStage.GROUP: {
       return formBuilder.group({
         type: [PipelineStage.GROUP],
+        preview: true,
         form: formBuilder.group({
           groupBy: formBuilder.array(
             get(value, 'form.groupBy', [{}]).map((x: any) => groupByRuleForm(x))
@@ -89,6 +92,7 @@ export const addStage = (value: any) => {
     case PipelineStage.ADD_FIELDS: {
       return formBuilder.group({
         type: [PipelineStage.ADD_FIELDS],
+        preview: true,
         form: formBuilder.array(
           value.form
             ? value.form.map((x: any) => addFieldsForm(x))
@@ -100,6 +104,7 @@ export const addStage = (value: any) => {
     case PipelineStage.UNWIND: {
       return formBuilder.group({
         type: [PipelineStage.UNWIND],
+        preview: true,
         form: formBuilder.group({
           field: [get(value, 'form.field', ''), Validators.required],
         }),
@@ -108,6 +113,7 @@ export const addStage = (value: any) => {
     case PipelineStage.CUSTOM: {
       const formGroup = formBuilder.group({
         type: [PipelineStage.CUSTOM],
+        preview: true,
         form: formBuilder.group({
           raw: [get(value, 'form.raw', ''), Validators.required],
         }),
@@ -121,6 +127,7 @@ export const addStage = (value: any) => {
     default: {
       return formBuilder.group({
         type: [PipelineStage.CUSTOM],
+        preview: true,
         form: formBuilder.group({
           raw: [get(value, 'form.raw', ''), Validators.required],
         }),

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
@@ -1,25 +1,43 @@
-<ui-spinner size="large" *ngIf="loading"></ui-spinner>
-<ng-container *ngIf="!loading">
-  <div class="flex">
-    <!-- Selection of fields -->
-    <shared-tagbox
-      class="flex flex-1"
-      [choices$]="fields$"
-      [control]="$any(aggregationForm.get('sourceFields'))"
-      [label]="'components.aggregationBuilder.sourceFields' | translate"
-    ></shared-tagbox>
-  </div>
-  <!-- Pipeline builder -->
-  <div class="flex pipeline-content">
-    <shared-pipeline
-      [fields$]="selectedFields$"
-      [metaFields$]="metaFields$"
-      [pipelineForm]="pipelineForm"
-      (previewPipelineFormChange)="onPreviewPipelineFormChange($event)"
-    ></shared-pipeline>
-    <div class="aggregation-preview">{{ aggregationPreview | json }}</div>
-  </div>
-  <ui-button icon="remove_red_eye" category="primary" (click)="togglePreview()">
-    {{ 'components.aggregationBuilder.togglePreview' | translate }}
-  </ui-button>
-</ng-container>
+<div class="w-full h-full flex flex-col">
+  <ui-spinner size="large" *ngIf="loading"></ui-spinner>
+  <ng-container *ngIf="!loading">
+    <div class="flex">
+      <!-- Selection of fields -->
+      <shared-tagbox
+        class="flex flex-1"
+        [choices$]="fields$"
+        [control]="$any(aggregationForm.get('sourceFields'))"
+        [label]="'components.aggregationBuilder.sourceFields' | translate"
+      ></shared-tagbox>
+      <!-- Toggle preview -->
+      <ui-button
+        class="ml-3 mb-4 self-end max-h-min"
+        [icon]="showPreview ? 'visibility_off' : 'visibility'"
+        category="primary"
+        (click)="showPreview = !showPreview"
+        >{{
+          (showPreview
+            ? 'components.aggregationBuilder.preview.hide'
+            : 'components.aggregationBuilder.preview.show'
+          ) | translate
+        }}
+      </ui-button>
+    </div>
+    <!-- Pipeline builder -->
+    <div class="flex grow gap-2">
+      <shared-pipeline
+        class="basis-2/3 grow"
+        [fields$]="selectedFields$"
+        [metaFields$]="metaFields$"
+        [pipelineForm]="pipelineForm"
+        [showCheckboxes]="showPreview"
+      ></shared-pipeline>
+      <ngx-monaco-editor
+        class="!h-full basis-1/3"
+        *ngIf="showPreview"
+        [options]="editorOptions"
+        [(ngModel)]="aggregationPreview"
+      ></ngx-monaco-editor>
+    </div>
+  </ng-container>
+</div>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
@@ -10,9 +10,16 @@
     ></shared-tagbox>
   </div>
   <!-- Pipeline builder -->
-  <shared-pipeline
-    [fields$]="selectedFields$"
-    [metaFields$]="metaFields$"
-    [pipelineForm]="pipelineForm"
-  ></shared-pipeline>
+  <div class="flex pipeline-content">
+    <shared-pipeline
+      [fields$]="selectedFields$"
+      [metaFields$]="metaFields$"
+      [pipelineForm]="pipelineForm"
+      (previewPipelineForm)="onPreviewPipelineFormChange($event)"
+    ></shared-pipeline>
+    <div class="aggregation-preview">{{ aggregationPreview | json }} oii</div>
+  </div>
+  <ui-button icon="remove_red_eye" category="primary" (click)="togglePreview()">
+    {{ 'components.aggregationBuilder.togglePreview' | translate }}
+  </ui-button>
 </ng-container>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
@@ -15,9 +15,9 @@
       [fields$]="selectedFields$"
       [metaFields$]="metaFields$"
       [pipelineForm]="pipelineForm"
-      (previewPipelineForm)="onPreviewPipelineFormChange($event)"
+      (previewPipelineFormChange)="onPreviewPipelineFormChange($event)"
     ></shared-pipeline>
-    <div class="aggregation-preview">{{ aggregationPreview | json }} oii</div>
+    <div class="aggregation-preview">{{ aggregationPreview | json }}</div>
   </div>
   <ui-button icon="remove_red_eye" category="primary" (click)="togglePreview()">
     {{ 'components.aggregationBuilder.togglePreview' | translate }}

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.scss
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.scss
@@ -1,14 +1,3 @@
-ui-button {
-  margin-left: 1em;
-}
-
-.pipeline-content shared-pipeline {
-  flex: 1;
-  box-sizing: border-box;
-}
-
-.aggregation-preview {
-  flex: 0 0 30%;
-  box-sizing: border-box;
-  display: none;
+::ng-deep ui-button button {
+  @apply h-11;
 }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.scss
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.scss
@@ -1,0 +1,14 @@
+ui-button {
+  margin-left: 1em;
+}
+
+.pipeline-content shared-pipeline {
+  flex: 1;
+  box-sizing: border-box;
+}
+
+.aggregation-preview {
+  flex: 0 0 30%;
+  box-sizing: border-box;
+  display: none;
+}

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -47,7 +47,7 @@ export class AggregationBuilderComponent
 
   public pipelinePreview: any;
 
-  public aggregationPreview: string = 'aggregation preview';
+  public aggregationPreview = 'aggregation preview';
   /**
    * Getter for the pipeline of the aggregation form
    *
@@ -133,10 +133,10 @@ export class AggregationBuilderComponent
   }
 
   public togglePreview() {
-    var aggregationPreview = document.querySelector(
+    let aggregationPreview = document.querySelector(
       '.aggregation-preview'
     ) as HTMLElement;
-    var pipelineContainer = document.getElementById(
+    let pipelineContainer = document.getElementById(
       'shared-pipeline'
     ) as HTMLElement;
     if (

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -133,6 +133,9 @@ export class AggregationBuilderComponent
     this.updateFields();
   }
 
+  /**
+   * Toggles the preview of the aggregation
+   */
   public togglePreview() {
     const aggregationPreview = document.querySelector(
       '.aggregation-preview'
@@ -152,7 +155,10 @@ export class AggregationBuilderComponent
     }
   }
 
-  onPreviewPipelineFormChange(pipeline: any) {
+  /**
+   * Updates the pipelinePreview
+   */
+  public onPreviewPipelineFormChange(pipeline: any) {
     this.pipelinePreview = pipeline;
     console.log('onPreviewPipelineFormChange', this.pipelinePreview);
   }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -48,6 +48,7 @@ export class AggregationBuilderComponent
   public pipelinePreview: any;
 
   public aggregationPreview = 'aggregation preview';
+
   /**
    * Getter for the pipeline of the aggregation form
    *
@@ -133,10 +134,10 @@ export class AggregationBuilderComponent
   }
 
   public togglePreview() {
-    let aggregationPreview = document.querySelector(
+    const aggregationPreview = document.querySelector(
       '.aggregation-preview'
     ) as HTMLElement;
-    let pipelineContainer = document.getElementById(
+    const pipelineContainer = document.getElementById(
       'shared-pipeline'
     ) as HTMLElement;
     if (

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -60,7 +60,7 @@ export class AggregationBuilderComponent
     },
     lineNumbers: 'off',
   };
-
+  /** The text displayed in the aggregation result preview */
   public aggregationPreview = '';
 
   /**
@@ -153,11 +153,13 @@ export class AggregationBuilderComponent
             sourceFields: value.sourceFields,
           })
           .subscribe((result) => {
+            // Update the preview with the error message
             if (result.errors?.[0]) {
               this.aggregationPreview = result.errors[0].message;
               return;
             }
 
+            // Update the preview with the items from the aggregation
             this.aggregationPreview = JSON.stringify(
               result.data?.recordsAggregation?.items ?? [],
               null,

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -45,6 +45,9 @@ export class AggregationBuilderComponent
   private mappingFields = new BehaviorSubject<any[]>([]);
   public mappingFields$!: Observable<any[]>;
 
+  public pipelinePreview: any;
+
+  public aggregationPreview: string = 'aggregation preview';
   /**
    * Getter for the pipeline of the aggregation form
    *
@@ -127,6 +130,30 @@ export class AggregationBuilderComponent
    */
   private initFields(): void {
     this.updateFields();
+  }
+
+  public togglePreview() {
+    var aggregationPreview = document.querySelector(
+      '.aggregation-preview'
+    ) as HTMLElement;
+    var pipelineContainer = document.getElementById(
+      'shared-pipeline'
+    ) as HTMLElement;
+    if (
+      aggregationPreview.style.display === 'none' ||
+      aggregationPreview.style.display === ''
+    ) {
+      aggregationPreview.style.display = 'block';
+      pipelineContainer.style.flex = '1';
+    } else {
+      aggregationPreview.style.display = 'none';
+      pipelineContainer.style.flex = '1';
+    }
+  }
+
+  onPreviewPipelineFormChange(pipeline: any) {
+    this.pipelinePreview = pipeline;
+    console.log('onPreviewPipelineFormChange', this.pipelinePreview);
   }
 
   /**

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -12,6 +12,7 @@ import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.compon
 import { takeUntil } from 'rxjs/operators';
 import { Apollo } from 'apollo-angular';
 import { GET_FIELDS_METADATA } from './graphql/queries';
+import { AggregationService } from '../../../services/aggregation/aggregation.service';
 
 /**
  * Main component of Aggregation builder.
@@ -45,9 +46,22 @@ export class AggregationBuilderComponent
   private mappingFields = new BehaviorSubject<any[]>([]);
   public mappingFields$!: Observable<any[]>;
 
+  /** Result of the current pipeline */
   public pipelinePreview: any;
+  /** Whether or not to display the aggregation result preview */
+  public showPreview = false;
+  /** Monaco editor options */
+  readonly editorOptions = {
+    theme: 'vs-dark',
+    language: 'jsonc',
+    fixedOverflowWidgets: false,
+    minimap: {
+      enabled: false,
+    },
+    lineNumbers: 'off',
+  };
 
-  public aggregationPreview = 'aggregation preview';
+  public aggregationPreview = '';
 
   /**
    * Getter for the pipeline of the aggregation form
@@ -63,11 +77,13 @@ export class AggregationBuilderComponent
    *
    * @param queryBuilder This is a service that is used to build queries.
    * @param aggregationBuilder This is the service that will be used to build the aggregation query.
+   * @param aggregationService This is the service that will be used to build the aggregation query.
    * @param apollo Shared apollo service
    */
   constructor(
     private queryBuilder: QueryBuilderService,
     private aggregationBuilder: AggregationBuilderService,
+    private aggregationService: AggregationService,
     private apollo: Apollo
   ) {
     super();
@@ -123,6 +139,32 @@ export class AggregationBuilderComponent
         // Trigger check on fields being removable or not
         this.fields.next(this.fields.getValue());
       });
+
+    // For the result preview
+    this.aggregationForm.valueChanges
+      .pipe(takeUntil(this.destroy$), debounceTime(1000))
+      .subscribe((value: any) => {
+        if (!this.resource.id) {
+          return;
+        }
+        this.aggregationService
+          .aggregationDataQuery(this.resource.id, {
+            pipeline: (value.pipeline ?? []).filter((x: any) => x.preview),
+            sourceFields: value.sourceFields,
+          })
+          .subscribe((result) => {
+            if (result.errors?.[0]) {
+              this.aggregationPreview = result.errors[0].message;
+              return;
+            }
+
+            this.aggregationPreview = JSON.stringify(
+              result.data?.recordsAggregation?.items ?? [],
+              null,
+              2
+            );
+          });
+      });
     this.loading = false;
   }
 
@@ -131,36 +173,6 @@ export class AggregationBuilderComponent
    */
   private initFields(): void {
     this.updateFields();
-  }
-
-  /**
-   * Toggles the preview of the aggregation
-   */
-  public togglePreview() {
-    const aggregationPreview = document.querySelector(
-      '.aggregation-preview'
-    ) as HTMLElement;
-    const pipelineContainer = document.getElementById(
-      'shared-pipeline'
-    ) as HTMLElement;
-    if (
-      aggregationPreview.style.display === 'none' ||
-      aggregationPreview.style.display === ''
-    ) {
-      aggregationPreview.style.display = 'block';
-      pipelineContainer.style.flex = '1';
-    } else {
-      aggregationPreview.style.display = 'none';
-      pipelineContainer.style.flex = '1';
-    }
-  }
-
-  /**
-   * Updates the pipelinePreview
-   */
-  public onPreviewPipelineFormChange(pipeline: any) {
-    this.pipelinePreview = pipeline;
-    console.log('onPreviewPipelineFormChange', this.pipelinePreview);
   }
 
   /**

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.module.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.module.ts
@@ -6,8 +6,7 @@ import { PipelineModule } from './pipeline/pipeline.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TagboxModule } from '../tagbox/tagbox.module';
 import { GridModule } from '../core-grid/grid/grid.module';
-import { SpinnerModule } from '@oort-front/ui';
-
+import { SpinnerModule, CheckboxModule, ButtonModule } from '@oort-front/ui';
 /**
  * Aggregation Builder module.
  * Used by edit-aggregation-modal component.
@@ -23,6 +22,8 @@ import { SpinnerModule } from '@oort-front/ui';
     PipelineModule,
     GridModule,
     SpinnerModule,
+    CheckboxModule,
+    ButtonModule,
   ],
   exports: [AggregationBuilderComponent],
 })

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.module.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.module.ts
@@ -7,6 +7,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TagboxModule } from '../tagbox/tagbox.module';
 import { GridModule } from '../core-grid/grid/grid.module';
 import { SpinnerModule, CheckboxModule, ButtonModule } from '@oort-front/ui';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+
 /**
  * Aggregation Builder module.
  * Used by edit-aggregation-modal component.
@@ -24,6 +26,7 @@ import { SpinnerModule, CheckboxModule, ButtonModule } from '@oort-front/ui';
     SpinnerModule,
     CheckboxModule,
     ButtonModule,
+    MonacoEditorModule,
   ],
   exports: [AggregationBuilderComponent],
 })

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
@@ -20,14 +20,11 @@
         "
       ></ui-icon>
       <ui-checkbox
+        *ngIf="showCheckboxes"
         (click)="$event.stopPropagation()"
-        [checked]="checked"
-        (change)="onCheckboxChange(index)"
-        class="includeStageCheckbox"
+        [formControl]="$any(stageForm).controls.preview"
+        class="ml-auto"
       >
-        <ng-container ngProjectAs="label">
-          {{ 'components.aggregationBuilder.stages.enabled' | translate }}
-        </ng-container>
       </ui-checkbox>
     </ng-container>
     <ng-container [ngSwitch]="stageForm.value.type">

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
@@ -19,6 +19,16 @@
             | translate
         "
       ></ui-icon>
+      <ui-checkbox
+        (click)="$event.stopPropagation()"
+        [checked]="checked"
+        (change)="onCheckboxChange(index)"
+        class="includeStageCheckbox"
+      >
+        <ng-container ngProjectAs="label">
+          {{ 'components.aggregationBuilder.stages.enabled' | translate }}
+        </ng-container>
+      </ui-checkbox>
     </ng-container>
     <ng-container [ngSwitch]="stageForm.value.type">
       <ng-container *ngSwitchCase="stageType.FILTER">

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
@@ -13,3 +13,7 @@
   padding: 16px 8px 16px 24px;
   margin-top: 1em;
 }
+
+.includeStageCheckbox {
+  margin-left: 1em;
+}

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
@@ -14,6 +14,6 @@
   margin-top: 1em;
 }
 
-.includeStageCheckbox {
-  margin-left: 1em;
+::ng-deep .accordion-item span {
+  @apply flex w-full;
 }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
@@ -40,7 +40,7 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
 
   public previewPipelineForm: UntypedFormArray = new UntypedFormArray([]);
 
-  public checked: boolean = true;
+  public checked = true;
 
   @Output() previewPipelineFormChange = new EventEmitter<any>();
 

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
@@ -38,10 +38,13 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
   /** Input decorator for pipelineForm. */
   @Input() pipelineForm!: UntypedFormArray;
 
+  /** Preview pipelineForm */
   public previewPipelineForm: UntypedFormArray = new UntypedFormArray([]);
 
+  /** Initial value for checkboxes */
   public checked = true;
 
+  /** Output decorator for previewPipelineFormChange. */
   @Output() previewPipelineFormChange = new EventEmitter<any>();
 
   /**

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { UntypedFormArray } from '@angular/forms';
 import { AggregationBuilderService } from '../../../../services/aggregation-builder/aggregation-builder.service';
 import { Observable } from 'rxjs';
@@ -8,7 +8,6 @@ import { debounceTime } from 'rxjs/operators';
 import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
-import * as _ from 'lodash';
 
 /**
  * Aggregation pipeline component.
@@ -35,17 +34,11 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
   /** Array to hold the fields per stage. */
   public fieldsPerStage: any[] = [];
 
+  /** Whether or not to show the pipeline checkboxes */
+  @Input() showCheckboxes = true;
+
   /** Input decorator for pipelineForm. */
   @Input() pipelineForm!: UntypedFormArray;
-
-  /** Preview pipelineForm */
-  public previewPipelineForm: UntypedFormArray = new UntypedFormArray([]);
-
-  /** Initial value for checkboxes */
-  public checked = true;
-
-  /** Output decorator for previewPipelineFormChange. */
-  @Output() previewPipelineFormChange = new EventEmitter<any>();
 
   /**
    * Aggregation pipeline component.
@@ -58,7 +51,6 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
 
   /** OnInit lifecycle hook. */
   ngOnInit(): void {
-    this.previewPipelineForm = _.cloneDeep(this.pipelineForm);
     this.fields$.subscribe((fields: any[]) => {
       this.initialFields = [...fields];
       this.fieldsPerStage = [];
@@ -73,15 +65,6 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
       .subscribe((pipeline: any[]) => {
         this.updateFieldsPerStage(pipeline);
       });
-  }
-
-  onCheckboxChange(index: number) {
-    if (this.previewPipelineForm.at(index).enabled == false) {
-      this.previewPipelineForm.at(index).enable();
-    } else {
-      this.previewPipelineForm.at(index).disable();
-    }
-    this.previewPipelineFormChange.emit(this.previewPipelineForm.value);
   }
 
   /**
@@ -116,8 +99,6 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
    */
   public addStage(type: string) {
     this.pipelineForm.push(addStage({ type }));
-    this.previewPipelineForm.push(addStage({ type }));
-    this.previewPipelineFormChange.emit(this.previewPipelineForm.value);
   }
 
   /**
@@ -127,8 +108,6 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
    */
   public deleteStage(index: number) {
     this.pipelineForm.removeAt(index);
-    this.previewPipelineForm.removeAt(index);
-    this.previewPipelineFormChange.emit(this.previewPipelineForm.value);
   }
 
   /**
@@ -141,11 +120,5 @@ export class PipelineComponent extends UnsubscribeComponent implements OnInit {
 
     this.pipelineForm.removeAt(event.previousIndex);
     this.pipelineForm.insert(event.currentIndex, temp);
-
-    const tempPreview = this.previewPipelineForm.at(event.previousIndex);
-    this.previewPipelineForm.removeAt(event.previousIndex);
-    this.previewPipelineForm.insert(event.currentIndex, tempPreview);
-
-    this.previewPipelineFormChange.emit(this.previewPipelineForm.value);
   }
 }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.module.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.module.ts
@@ -20,6 +20,7 @@ import {
   ExpansionPanelModule,
   SelectMenuModule,
   IconModule,
+  CheckboxModule,
 } from '@oort-front/ui';
 
 /**
@@ -50,6 +51,7 @@ import {
     ButtonModule,
     FormWrapperModule,
     SelectMenuModule,
+    CheckboxModule,
   ],
   exports: [
     PipelineComponent,

--- a/libs/shared/src/lib/services/aggregation/aggregation.service.ts
+++ b/libs/shared/src/lib/services/aggregation/aggregation.service.ts
@@ -88,7 +88,7 @@ export class AggregationService {
    */
   aggregationDataQuery(
     resource: string,
-    aggregation: string,
+    aggregation: string | Aggregation,
     mapping?: any,
     contextFilters?: CompositeFilterDescriptor,
     at?: Date
@@ -158,7 +158,13 @@ export class AggregationService {
         id: aggregation.id,
         resource,
         form,
-        aggregation: value,
+        aggregation: {
+          ...value,
+          pipeline: value.pipeline.map((x: any) => ({
+            type: x.type,
+            form: x.form,
+          })),
+        },
       },
     });
   }

--- a/libs/shared/src/lib/services/aggregation/graphql/queries.ts
+++ b/libs/shared/src/lib/services/aggregation/graphql/queries.ts
@@ -32,7 +32,7 @@ export const GET_RESOURCE_AGGREGATIONS = gql`
 export const GET_AGGREGATION_DATA = gql`
   query GetAggregationData(
     $resource: ID!
-    $aggregation: ID!
+    $aggregation: JSON!
     $mapping: JSON
     $first: Int
     $skip: Int


### PR DESCRIPTION
# Description

Included checklists in each aggregation stage to include or exclude them for a real-time preview inside aggregation-builder, which can be viewed by a toggle button. I got as far as to update the previewPipeline which is the pipeline without the unchecked stages, but I could not add a real time query inside aggregation builder from just the pipeline data without it being saved into an aggregation and therefore not linked to a resource.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-181
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/oort-backend/pull/6

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- On aggregation builder open, all checkboxes for the preexisting stages and new stages should be ticked. That means every stage of the pipeline is in the previewPipeline. When you untick a box, add a stage, delete a stage or change the order of the stages, the previewPipeline changes and this emits from pipeline component into aggregation builder component (which I am logging). The previewPipeline functions work correctly but the real time preview functionality is still not implemented, just its skeleton.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/4f481610-39a4-450f-89ec-a53241fd2895)
![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/486d51a6-c121-4758-9411-4a0b0f918011)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings

# To do:

- Figure out how to query an aggregation result just from the previewPipeline and resource (instead of having a saved aggregation and a resource which it is already linked to) in aggregation-builder and update it in real time to aggregationPreview variable.