### PR TITLE
fix/HIT-189_Sometimes-operator-does-not-show-on-aggregation-builder

### DIFF
--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -157,6 +157,7 @@ export class AggregationBuilderComponent
           this.updateSelectedAndMetaFields(
             this.aggregationForm.value.sourceFields
           );
+          this.metaFields.next(data.resource.metadata);
         } else {
           this.metaFields.next([]);
         }


### PR DESCRIPTION
# Description

Sometimes operator doesn't show on aggregation builder.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-189

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just create new aggregation and seeing if it shows the operator in the first open.

## Screenshots

Before:

https://github.com/ReliefApplications/oort-frontend/assets/24783896/b750a72f-644a-4abc-9b0a-8bd142c4d1a6



After:

https://github.com/ReliefApplications/oort-frontend/assets/24783896/fc0fd54c-9190-4b9e-a45e-d4ddf2ec444c



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
