### PR TITLE
HIT-192 Aggregation builder label stage

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -454,6 +454,7 @@
 			"addField": "Add field",
 			"addRule": "Add rule",
 			"addStage": "Add stage",
+			"copyFrom": "Copy labels from",
 			"dataset": {
 				"select": "Select the data source"
 			},

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -491,6 +491,7 @@
 				"custom": "Custom",
 				"filter": "Filter",
 				"group": "Group",
+				"label": "Label",
 				"sort": "Sort",
 				"unwind": "Unwind"
 			},
@@ -499,6 +500,7 @@
 				"custom": "Defines a custom aggregation function or expression in JavaScript.",
 				"filter": "Returns an array with only those elements that match the condition.",
 				"group": "Groups input documents by the specified 'id' expression and for each distinct grouping, outputs a document.",
+				"label": "Replaces the choice values for the choice texts (if defined) in the specified field.",
 				"selectedFields": "Only unused fields can removed.",
 				"sort": "Sorts all input documents and returns them to the pipeline in sorted order.",
 				"unwind": "Deconstructs an array field from the input documents to output a document for each element."
@@ -951,6 +953,9 @@
 				"fields": "Select data points below and drag them to 'selected fields' on the right",
 				"sortingDisabled": "Sorting fields is disabled when search is active",
 				"style": "Styling rules make records with important information stand out. When a record matches more than one rule, the first rule is used."
+			},
+			"label": {
+				"field": "Field"
 			},
 			"pagination": {
 				"first": "Limit",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -454,6 +454,7 @@
 			"addField": "Ajouter un champ",
 			"addRule": "Ajouter une règle",
 			"addStage": "Ajouter une étape",
+			"copyFrom": "Copier les étiquettes de",
 			"dataset": {
 				"select": "Sélectionner la source de données"
 			},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -491,6 +491,7 @@
 				"custom": "Personnaliser",
 				"filter": "Filtrer",
 				"group": "Grouper",
+				"label": "Étiqueter",
 				"sort": "Trier",
 				"unwind": "Dissocier"
 			},
@@ -499,6 +500,7 @@
 				"custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
 				"filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
 				"group": "Regroupe les documents mis en entrée par l'expression 'id' qui a été spécifiée et qui sort un document pour chaque regroupement.",
+				"label": "Remplace les valeurs de choix pour les textes de choix (si définis) dans le champ spécifié.",
 				"selectedFields": "Seuls les champs non utilisés peuvent être supprimés.",
 				"sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.",
 				"unwind": "Déconstruit un tableau depuis les documents d'entrée et ressort un document pour chaque élément."
@@ -956,6 +958,9 @@
 				"fields": "Sélectionnez des champs ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite",
 				"sortingDisabled": "Le tri est désactivé quand la recherche est active.",
 				"style": "Les règles de style font ressortir les enregistrements contenant des informations importantes. Quand un enregistrement vérifie plusieurs règles, la première est utilisée."
+			},
+			"label": {
+				"field": "Champ"
 			},
 			"pagination": {
 				"first": "Limite",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -491,6 +491,7 @@
 				"custom": "******",
 				"filter": "******",
 				"group": "******",
+				"label": "******",
 				"sort": "******",
 				"unwind": "******"
 			},
@@ -499,6 +500,7 @@
 				"custom": "******",
 				"filter": "******",
 				"group": "******",
+				"label": "******",
 				"selectedFields": "******",
 				"sort": "******",
 				"unwind": "******"
@@ -951,6 +953,9 @@
 				"fields": "******",
 				"sortingDisabled": "******",
 				"style": "******"
+			},
+			"label": {
+				"field": "******"
 			},
 			"pagination": {
 				"first": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -454,6 +454,7 @@
 			"addField": "******",
 			"addRule": "******",
 			"addStage": "******",
+			"copyFrom": "******",
 			"dataset": {
 				"select": "******"
 			},

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
@@ -124,6 +124,14 @@ export const addStage = (value: any) => {
         ?.setValidators([Validators.required, jsonValidator]);
       return formGroup;
     }
+    case PipelineStage.LABEL: {
+      return formBuilder.group({
+        type: [PipelineStage.LABEL],
+        form: formBuilder.group({
+          field: [get(value, 'form.field', ''), Validators.required],
+        }),
+      });
+    }
     default: {
       return formBuilder.group({
         type: [PipelineStage.CUSTOM],

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder-forms.ts
@@ -127,8 +127,10 @@ export const addStage = (value: any) => {
     case PipelineStage.LABEL: {
       return formBuilder.group({
         type: [PipelineStage.LABEL],
+        preview: true,
         form: formBuilder.group({
           field: [get(value, 'form.field', ''), Validators.required],
+          copyFrom: [get(value, 'form.copyFrom', ''), Validators.required],
         }),
       });
     }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -59,6 +59,7 @@ export class AggregationBuilderComponent
       enabled: false,
     },
     lineNumbers: 'off',
+    automaticLayout: true,
   };
   /** The text displayed in the aggregation result preview */
   public aggregationPreview = '';

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.html
@@ -1,0 +1,20 @@
+<form [formGroup]="form">
+  <div class="flex gap-2">
+    <div uiFormFieldDirective class="flex-1">
+      <label>{{ 'components.queryBuilder.label.field' | translate }}</label>
+      <ui-select-menu formControlName="field">
+        <ui-select-option>{{
+          'common.input.none' | translate
+        }}</ui-select-option>
+        <ng-container *ngFor="let field of fields">
+          <ui-select-option
+            [value]="field.name"
+            *ngIf="getChoiceQuestionNames().includes(field.name)"
+          >
+            {{ field.name }}
+          </ui-select-option>
+        </ng-container>
+      </ui-select-menu>
+    </div>
+  </div>
+</form>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.html
@@ -7,11 +7,21 @@
           'common.input.none' | translate
         }}</ui-select-option>
         <ng-container *ngFor="let field of fields">
-          <ui-select-option
-            [value]="field.name"
-            *ngIf="getChoiceQuestionNames().includes(field.name)"
-          >
+          <ui-select-option [value]="field.name">
             {{ field.name }}
+          </ui-select-option>
+        </ng-container>
+      </ui-select-menu>
+    </div>
+    <div uiFormFieldDirective class="flex-1">
+      <label>{{ 'components.aggregationBuilder.copyFrom' | translate }}</label>
+      <ui-select-menu formControlName="copyFrom">
+        <ui-select-option>{{
+          'common.input.none' | translate
+        }}</ui-select-option>
+        <ng-container *ngFor="let field of choiceFields">
+          <ui-select-option [value]="field">
+            {{ field }}
           </ui-select-option>
         </ng-container>
       </ui-select-menu>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.spec.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LabelStageComponent } from './label-stage.component';
+
+describe('LabelStageComponent', () => {
+  let component: LabelStageComponent;
+  let fixture: ComponentFixture<sharedLabelStageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LabelStageComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LabelStageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.ts
@@ -1,0 +1,35 @@
+import { Component, Input } from '@angular/core';
+import { UntypedFormGroup } from '@angular/forms';
+
+/**
+ * Component that handles labeling
+ */
+@Component({
+  selector: 'shared-label-stage',
+  templateUrl: './label-stage.component.html',
+  styleUrls: ['./label-stage.component.scss'],
+})
+export class LabelStageComponent {
+  @Input() form: UntypedFormGroup = new UntypedFormGroup({});
+  @Input() fields: any[] = [];
+  @Input() showLimit = false;
+  @Input() metaFields: any[] = [];
+
+  /**
+   * Returns the list of choice question names
+   * @returns the list of choice question names
+   */
+  public getChoiceQuestionNames() {
+    const choiceQuestionTypes = [
+      'dropdown',
+      'checkbox',
+      'radiogroup',
+      'tagbox',
+      'matrixdropdown',
+      'matrixdynamic',
+    ];
+    return Object.entries(this.metaFields)
+      .filter(([, value]) => choiceQuestionTypes.includes(value.type))
+      .map(([, value]) => value.name);
+  }
+}

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/label-stage/label-stage.component.ts
@@ -1,5 +1,13 @@
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
+import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.component';
+import { takeUntil } from 'rxjs';
 
 /**
  * Component that handles labeling
@@ -9,27 +17,58 @@ import { UntypedFormGroup } from '@angular/forms';
   templateUrl: './label-stage.component.html',
   styleUrls: ['./label-stage.component.scss'],
 })
-export class LabelStageComponent {
+export class LabelStageComponent
+  extends UnsubscribeComponent
+  implements OnInit, OnChanges
+{
   @Input() form: UntypedFormGroup = new UntypedFormGroup({});
   @Input() fields: any[] = [];
   @Input() showLimit = false;
   @Input() metaFields: any[] = [];
 
+  /** List of available fields that could have choices */
+  public choiceFields: string[] = [];
+
   /**
-   * Returns the list of choice question names
-   * @returns the list of choice question names
+   * Component that handles labeling
    */
-  public getChoiceQuestionNames() {
-    const choiceQuestionTypes = [
-      'dropdown',
-      'checkbox',
-      'radiogroup',
-      'tagbox',
-      'matrixdropdown',
-      'matrixdynamic',
-    ];
-    return Object.entries(this.metaFields)
-      .filter(([, value]) => choiceQuestionTypes.includes(value.type))
-      .map(([, value]) => value.name);
+  constructor() {
+    super();
+  }
+
+  /** Setup form behavior */
+  ngOnInit(): void {
+    this.form
+      .get('field')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((field) => {
+        if (this.choiceFields.includes(field)) {
+          this.form.get('copyFrom')?.setValue(field);
+        } else {
+          this.form.get('copyFrom')?.setValue(null);
+        }
+      });
+  }
+
+  /**
+   * Recalculates the choice fields based on current inputted fields
+   *
+   * @param changes the changes object
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.fields) {
+      this.choiceFields = Object.entries(this.metaFields)
+        .filter(([, value]) =>
+          [
+            'dropdown',
+            'checkbox',
+            'radiogroup',
+            'tagbox',
+            'matrixdropdown',
+            'matrixdynamic',
+          ].includes(value.type)
+        )
+        .map(([, value]) => value.name);
+    }
   }
 }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline-stage.enum.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline-stage.enum.ts
@@ -8,4 +8,5 @@ export enum PipelineStage {
   ADD_FIELDS = 'addFields',
   UNWIND = 'unwind',
   CUSTOM = 'custom',
+  LABEL = 'label',
 }

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
@@ -58,6 +58,13 @@
           [fields]="fieldsPerStage[index]"
         ></shared-field-dropdown>
       </ng-container>
+      <ng-container *ngSwitchCase="stageType.LABEL">
+        <shared-label-stage
+          [form]="$any(stageForm).controls.form"
+          [fields]="fieldsPerStage[index]"
+          [metaFields]="metaFields"
+        ></shared-label-stage>
+      </ng-container>
       <ng-container *ngSwitchCase="stageType.CUSTOM">
         <div uiFormFieldDirective>
           <label>{{ 'common.input.rawJson' | translate }}</label>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.module.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/pipeline.module.ts
@@ -11,6 +11,7 @@ import { FieldDropdownComponent } from './field-dropdown/field-dropdown.componen
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { FilterModule } from '../../../filter/filter.module';
 import { SortStageComponent } from './sort-stage/sort-stage.component';
+import { LabelStageComponent } from './label-stage/label-stage.component';
 import {
   TextareaModule,
   FormWrapperModule,
@@ -34,6 +35,7 @@ import {
     ExpressionsComponent,
     FieldDropdownComponent,
     SortStageComponent,
+    LabelStageComponent,
   ],
   imports: [
     CommonModule,
@@ -60,6 +62,7 @@ import {
     ExpressionsComponent,
     FieldDropdownComponent,
     SortStageComponent,
+    LabelStageComponent,
   ],
 })
 export class PipelineModule {}


### PR DESCRIPTION
# Description

Included "Label" stage for the aggregation builder, which replaces the values of the answers with their texts.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-192
- https://github.com/ReliefApplications/oort-backend/tree/HIT-192-add-label-stage-to-aggregation-builder

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

## Screenshots



# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# To do:

- Make it work for choices internal to the matrix