### PR TITLE
HIT-205 When the VisibleIf property is cleared, sets the question to visible

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -53,6 +53,17 @@ export const init = (environment: any): void => {
     ],
   };
 
+  // When the VisibleIf property is cleared, sets the question to visible
+  serializer.getProperty('question', 'visibleIf').onSettingValue = (
+    question: Question,
+    newValue: string
+  ) => {
+    if (question.visibleIf && !newValue) {
+      question.setPropertyValue('visible', true);
+    }
+    return newValue;
+  };
+
   // Adds property that clears the value when condition is met
   serializer.addProperty('question', {
     name: 'clearIf:condition',


### PR DESCRIPTION
# Description

When setting a VisibleIf condition for a question, surveyJS disables the visible checkbox. Now, when a visibleIf condition is cleared (manually or clear button), the visible property is set to true automatically.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-205

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- Set a VisibleIf condition for a question then clear it. This was also tested by saving the form/reloading page in between steps and trying to check/uncheck the visible checkbox before setting visibleIf condition.

## Screenshots

![chrome-capture-2023-11-21](https://github.com/ReliefApplications/oort-frontend/assets/39497117/daa77508-8f51-4464-be55-7c52154c28dd)
![chrome-capture-2023-11-21 (1)](https://github.com/ReliefApplications/oort-frontend/assets/39497117/f80f3262-5f1b-4f4c-83e9-0b97556259fe)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
