### PR TITLE
HIT-211: Logic fix for non-string values on context filters

### DIFF
--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -8,7 +8,7 @@ import {
   FilterDescriptor,
 } from '@progress/kendo-data-query';
 import { cloneDeep } from '@apollo/client/utilities';
-import { isNil, isEmpty, get, isEqual } from 'lodash';
+import { isNil, isEmpty, get, isEqual, isObject } from 'lodash';
 import { DashboardService } from '../dashboard/dashboard.service';
 
 /**
@@ -164,10 +164,12 @@ export class ContextService {
           // Filter out fields that are not in the available filter field
           // Meaning, their values are still using the {{filter.}} syntax
           if ('value' in f && !f.field?.toString().startsWith('__FILTER__.')) {
-            return !isNil(f.value) && !isEmpty(f.value);
-            // const filterName = f.value?.match(regex)?.[0];
-            // return !(filterName && !availableFilterFields[filterName]);
-          } else return true;
+            return isObject(f.value)
+              ? !isNil(f.value) && !isEmpty(f.value)
+              : !isNil(f.value);
+          } else {
+            return true;
+          }
           // return true;
         });
     }


### PR DESCRIPTION
# Description

Context filters on widgets would only work for strings. Otherwise the graphql request would show and empty filters array

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-211
- Backend pull request: https://github.com/ReliefApplications/oort-backend/pull/18

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested by setting up context filters using non-string values directly and from dashboard filters.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/48fc1ee9-605d-408e-ada4-ba631d8599d4)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
