### PR TITLE
HIT-223 Clear dashboard filter button (not properly working)

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -525,6 +525,7 @@
 			},
 			"customStyling": "Custom Styling",
 			"dashboard": {
+				"clearFields": "Clear fields",
 				"editFilter": "Edit filter",
 				"empty": "No content available. Wait for your administrator to build some.",
 				"filter": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -525,6 +525,7 @@
 			},
 			"customStyling": "Style personnalisé",
 			"dashboard": {
+				"clearFields": "Supprimer les champs",
 				"editFilter": "Modifier le filtre",
 				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée.",
 				"filter": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -525,6 +525,7 @@
 			},
 			"customStyling": "******",
 			"dashboard": {
+				"clearFields": "******",
 				"editFilter": "******",
 				"empty": "******",
 				"filter": {

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -113,6 +113,17 @@
             "
           >
           </ui-button>
+          <!-- Clear fields -->
+          <ui-button
+            variant="light"
+            [isIcon]="true"
+            icon="backspace"
+            (click)="clearFields()"
+            [uiTooltip]="
+              'components.application.dashboard.clearFields' | translate
+            "
+          >
+          </ui-button>
         </div>
         <!-- Quick filter -->
         <div

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -255,6 +255,15 @@ export class DashboardFilterComponent
       });
   }
 
+  /** Clear dashboard filter fields */
+  public clearFields() {
+    // TO DO: this doesn't work for kendo pickers such as tagbox as date
+    this.survey.clear();
+    //this.onValueChange();
+    //this.survey.render();
+    //this.changeDetectorRef.detectChanges();
+  }
+
   /**
    * Handle filter update mutation response depending of mutation type, for filter structure or position
    *

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -255,13 +255,10 @@ export class DashboardFilterComponent
       });
   }
 
-  /** Clear dashboard filter fields */
+  /** Clear dashboard filter values */
   public clearFields() {
-    // TO DO: this doesn't work for kendo pickers such as tagbox as date
     this.survey.clear();
-    //this.onValueChange();
-    //this.survey.render();
-    //this.changeDetectorRef.detectChanges();
+    this.onValueChange();
   }
 
   /**

--- a/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
@@ -97,6 +97,13 @@ export const init = (
         question.value = value;
       });
 
+      // On change, we update the value of the select
+      question.valueChangedCallback = () => {
+        if (question.value !== tagboxInstance.value) {
+          tagboxInstance.value = question.value;
+        }
+      };
+
       // We subscribe to whatever you write on the field so we can filter the data accordingly
       tagboxInstance.filterChange
         .pipe(

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -175,6 +175,21 @@ export const init = (
                 question.value = null;
               }
             });
+
+            // On change, we update the value of the select
+            question.valueChangedCallback = () => {
+              if (question.value !== pickerInstance.value?.toISOString()) {
+                try {
+                  pickerInstance.writeValue(
+                    (question.value ? new Date(question.value) : null) as any
+                  );
+                } catch {
+                  // There's no other way of programmatically clearing the date picker
+                  // besides setting the value to null, which throws an error
+                }
+              }
+            };
+
             if (question.value) {
               // Init the question with the date in the correct format
               pickerInstance.writeValue(


### PR DESCRIPTION
# Description

Creation of a clear fields button for dashboard filters.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-223

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Create a dashboard filter form, try some inputs in the fields and press clear. Currently it doesn't work for some kendo pickers such as date and tagbox but it works for simpler one such as dropdown.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/e3afbe7a-9368-4ce4-82ae-60d2a34d9d17)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
