### PR TITLE
feat/HIT-220 Allow HTML in dashboard filter

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -50,7 +50,7 @@ const QUESTION_TYPES = [
   // 'imagepicker',
   'boolean',
   // 'image',
-  // 'html',
+  'html',
   // 'signaturepad',
   // 'expression',
   // 'matrix',
@@ -132,6 +132,7 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'valueFalse',
   'valueName',
   'inputType',
+  'html',
 ];
 
 /**


### PR DESCRIPTION
# Description

Enabled the use of HTML questions in the dashboard filter builder for organizing purposes.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-220

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Simply set a HTML question in dashboard filter builder.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/39497117/345d0b8b-3b20-484e-bbff-e2ae6d63a4f8)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings