### PR TITLE
feat/HIT-204_automigrate-old-records

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -95,6 +95,57 @@ export const init = (environment: any): void => {
       }
     },
   });
+
+  // Adds a few properties to handle old records when the form structure changes
+  serializer.addProperty('survey', {
+    name: 'updateOldRecords:boolean',
+    category: 'Records',
+    default: false,
+  });
+
+  // If updateOldRecords is true, the user can choose what to do with the records that fail to convert
+  serializer.addProperty('survey', {
+    name: 'onConversionFail:dropdown',
+    category: 'Records',
+    choices: [
+      {
+        value: 'skip',
+        text: 'Remove value',
+      },
+      {
+        value: 'ignore',
+        text: 'Keep old value',
+      },
+      {
+        value: 'archive',
+        text: 'Archive record',
+      },
+    ],
+    default: 'skip',
+    visibleIf: (survey: SurveyModel) => survey.updateOldRecords,
+  });
+  // The user can also select the logic for choosing between multiple values if question with choices
+  serializer.addProperty('survey', {
+    name: 'strategyForArrays:dropdown',
+    category: 'Records',
+    choices: [
+      {
+        value: 'first',
+        text: 'First value',
+      },
+      {
+        value: 'last',
+        text: 'Last value',
+      },
+      {
+        value: 'random',
+        text: 'Random value',
+      },
+    ],
+    default: 'first',
+    visibleIf: (survey: SurveyModel) => survey.updateOldRecords,
+  });
+
   // change the prefix for comments
   settings.commentPrefix = '_comment';
   // override default expression properties


### PR DESCRIPTION
# Description

Mainly adds a few properties used in the [backend PR](https://github.com/ReliefApplications/oort-backend/pull/29)

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-204
- Please insert link to back-end branch if any: https://github.com/ReliefApplications/oort-backend/pull/29


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots

<img width="436" alt="image" src="https://github.com/ReliefApplications/oort-frontend/assets/102038450/a5dde32d-4ded-44d4-904a-ff2b22ce693c">

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
