### PR TITLE
Feat/hit 233 hide the navigation tab on the survey designer

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -136,6 +136,27 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
 ];
 
 /**
+ * Navigation tab properties (will be disabled).
+ */
+const NAVIGATION_PROPERTIES = [
+  'showPreviewBeforeComplete',
+  'pagePrevText',
+  'pageNextText',
+  'completeText',
+  'previewText',
+  'editText',
+  'startSurveyText',
+  'showNavigationButtons',
+  'showPrevButton',
+  'firstPageIsStarted',
+  'goNextPageAutomatic',
+  'showProgressBar',
+  'progressBarType',
+  'questionsOnPageMode',
+  'showTOC',
+];
+
+/**
  * Filter builder component
  */
 @Component({
@@ -213,6 +234,11 @@ export class FilterBuilderModalComponent
 
     // Block core fields edition
     this.surveyCreator.onShowingProperty.add((sender: any, opt: any) => {
+      // Disable navigation properties
+      if (NAVIGATION_PROPERTIES.includes(opt.property.name)) {
+        opt.canShow = false;
+      }
+
       // opt: { obj: any, property: Survey.JsonObjectProperty, canShow: boolean and more...}
       const obj = opt.obj;
       if (!obj || !obj.page) {
@@ -224,6 +250,8 @@ export class FilterBuilderModalComponent
         opt.canShow = false;
       }
     });
+    // Reset property grid to let it handle onShowingProperty event (cf doc)
+    this.surveyCreator.JSON = {};
 
     // add the rendering of custom properties
     this.surveyCreator.survey.onAfterRenderQuestion.add(

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -86,6 +86,27 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
 ];
 
 /**
+ * Navigation tab properties (will be disabled).
+ */
+const NAVIGATION_PROPERTIES = [
+  'showPreviewBeforeComplete',
+  'pagePrevText',
+  'pageNextText',
+  'completeText',
+  'previewText',
+  'editText',
+  'startSurveyText',
+  'showNavigationButtons',
+  'showPrevButton',
+  'firstPageIsStarted',
+  'goNextPageAutomatic',
+  'showProgressBar',
+  'progressBarType',
+  'questionsOnPageMode',
+  'showTOC',
+];
+
+/**
  * Class name to add to core field question.
  */
 const CORE_FIELD_CLASS = 'core-question';
@@ -197,6 +218,15 @@ export class FormBuilderComponent
     };
 
     this.surveyCreator = new SurveyCreatorModel(creatorOptions);
+
+    // Disable navigation properties
+    this.surveyCreator.onShowingProperty.add(function (sender, options) {
+      if (NAVIGATION_PROPERTIES.includes(options.property.name)) {
+        options.canShow = false;
+      }
+    });
+    // Reset property grid to let it handle onShowingProperty event (cf doc)
+    this.surveyCreator.JSON = {};
 
     (this.surveyCreator.onTestSurveyCreated as any).add(
       (_: any, options: any) => {


### PR DESCRIPTION
# Description

Is finished but needs to be tested

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-233)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
