### PR TITLE
Fix/hit 231 enable html question name edition

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -133,6 +133,7 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'valueName',
   'inputType',
   'html',
+  'htmlTitle',
 ];
 
 /**

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -83,7 +83,6 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'enableIf',
   'visibleIf',
   'tooltip',
-  'htmlTitle',
 ];
 
 /**

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -83,6 +83,7 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'enableIf',
   'visibleIf',
   'tooltip',
+  'htmlTitle',
 ];
 
 /**


### PR DESCRIPTION
# Description

I added an HTML title property to the HTML question, which changes the question name. When the value changes, it will generate a unique name.

By changing `name` instead of `valueName`, the changes are visible in real time from the editor. I used `valueName` to maintain consistency with the other questions (the name changes when saving the form).

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-231)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I created an HTML question in both forms and dashboard filters. I verified that the new property worked correctly.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/b5ed77d0-c3f1-4236-ac6b-c77c54f946d5)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
