### PR TITLE
Feat/hit 242 add option to navigate to page on map popups

### DIFF
--- a/apps/back-office/src/app/app-routing.module.ts
+++ b/apps/back-office/src/app/app-routing.module.ts
@@ -61,7 +61,7 @@ const routes: Routes = [
  * Use lazy loading for performance.
  */
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: true })],
+  imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
@@ -48,6 +48,11 @@ export interface LayerFormData {
     description: string;
     popupElements: PopupElement[];
     fieldsInfo?: Fields[];
+    navigateToPage?: boolean;
+    navigateSettings?: {
+      field: string;
+      pageUrl: string;
+    };
   };
   datasource?: {
     origin?: 'resource' | 'refData';

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -170,6 +170,11 @@ export class Layer implements LayerModel {
     title: '',
     description: '',
     popupElements: [],
+    navigateToPage: false,
+    navigateSettings: {
+      field: '',
+      pageUrl: '',
+    },
   };
   /** Created at */
   public createdAt!: Date;

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.html
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.html
@@ -30,6 +30,21 @@
         >
         </ui-button>
       </ng-container>
+      <ui-button
+        *ngIf="navigateToPage"
+        size="small"
+        [isIcon]="true"
+        icon="hyperlink-open-sm"
+        variant="light"
+        (click)="
+          navigate({
+            action: 'goTo',
+            pageUrl: navigateSettings.pageUrl,
+            field: navigateSettings.field
+          })
+        "
+        [uiTooltip]="'components.widget.grid.actions.goTo' | translate"
+      ></ui-button>
       <!-- Close popup -->
       <ui-button
         size="small"

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.html
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.html
@@ -34,15 +34,9 @@
         *ngIf="navigateToPage"
         size="small"
         [isIcon]="true"
-        icon="hyperlink-open-sm"
+        icon="launch"
         variant="light"
-        (click)="
-          navigate({
-            action: 'goTo',
-            pageUrl: navigateSettings.pageUrl,
-            field: navigateSettings.field
-          })
-        "
+        (click)="navigate(navigateSettings)"
         [uiTooltip]="'components.widget.grid.actions.goTo' | translate"
       ></ui-button>
       <!-- Close popup -->

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.ts
@@ -59,8 +59,8 @@ export class MapPopupComponent
   /** Current environment */
   private environment: any;
 
-  // TODO initialize
-  public navigateToPage = true;
+  /** Navigation info */
+  public navigateToPage = false;
   public navigateSettings = {
     field: '',
     pageUrl: '',
@@ -79,6 +79,8 @@ export class MapPopupComponent
   /**
    * Component for a popup that has information on multiple points
    *
+   * @param environment platform environment
+   * @param router Angular Router
    * @param sanitizer The dom sanitizer, to sanitize the template
    */
   constructor(
@@ -87,7 +89,7 @@ export class MapPopupComponent
     private sanitizer: DomSanitizer
   ) {
     super();
-    this.environment = environment.module || 'frontoffice';
+    this.environment = environment;
   }
 
   ngAfterContentInit(): void {
@@ -129,11 +131,17 @@ export class MapPopupComponent
     this.zoomTo.emit(this.coordinates);
   }
 
-  public navigate(event: any) {
-    let fullUrl = this.getPageUrl(event.pageUrl as string);
-    if (event.field) {
-      const field = get(event, 'field', '');
-      const value = get(event, `item.${field}`);
+  /**
+   * Create and navigate to the specified url
+   * @param navigateSettings navigation settings
+   */
+  public navigate(navigateSettings: any) {
+    // Closing the popup manually, otherwise, the tooltip isn't destroyed properly
+    this.closePopup.emit();
+    let fullUrl = this.getPageUrl(navigateSettings.pageUrl as string);
+    if (navigateSettings.field) {
+      const field = get(navigateSettings, 'field', '');
+      const value = get(this.feature[this.currValue].properties, field);
       fullUrl = `${fullUrl}?id=${value}`;
     }
     this.router.navigateByUrl(fullUrl);

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
@@ -300,6 +300,10 @@ export class MapPopupService {
     // set the component inputs
     instance.feature = featurePoints;
     instance.coordinates = coordinates;
+    instance.navigateToPage = popupInfo.navigateToPage || false;
+    if (popupInfo.navigateSettings) {
+      instance.navigateSettings = popupInfo.navigateSettings;
+    }
 
     // Bind zoom
     instance.currZoom = this.map.getZoom();

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
@@ -43,7 +43,85 @@
           ></ui-icon>
         </div>
       </div>
-      <ui-divider class="my-1"></ui-divider>
+
+      <ui-toggle [formControlName]="navigateOptions.name">
+        <ng-container ngProjectAs="label">
+          {{ navigateOptions.text | translate
+          }}<ui-icon
+            *ngIf="navigateOptions.tooltip"
+            class="ml-2 cursor-help"
+            variant="grey"
+            icon="info_outline"
+            [size]="18"
+            [uiTooltip]="navigateOptions.tooltip | translate"
+            uiTooltipPosition="right"
+          ></ui-icon>
+        </ng-container>
+      </ui-toggle>
+      <!-- Redirect to specific page action details -->
+      <div
+        *ngIf="showSelectPage"
+        formGroupName="navigateSettings"
+        class="flex flex-col ml-[55px]"
+      >
+        <div uiFormFieldDirective class="w-80">
+          <label>
+            {{
+              'components.widget.settings.grid.actions.pageUrl.label'
+                | translate
+            }}
+          </label>
+          <ui-select-menu
+            formControlName="pageUrl"
+            [placeholder]="
+              'components.widget.settings.grid.actions.pageUrl.placeholder'
+                | translate
+            "
+          >
+            <ui-select-option
+              *ngFor="let page of pages"
+              [value]="page.urlParams"
+            >
+              {{ page.name }}
+            </ui-select-option>
+          </ui-select-menu>
+        </div>
+        <div uiFormFieldDirective class="w-80">
+          {{
+            'components.widget.settings.grid.actions.goTo.field.label'
+              | translate
+          }}
+          <ui-select-menu
+            formControlName="field"
+            [placeholder]="
+              'components.widget.settings.grid.actions.goTo.field.placeholder'
+                | translate
+            "
+          >
+            <ng-container *ngFor="let field of fields">
+              <ui-select-option *ngIf="!field.fields" [value]="field.name">
+                {{ field.text || field.name }}
+              </ui-select-option>
+
+              <ui-select-option *ngIf="field.fields" [isGroup]="true">
+                {{ field.text || field.name }}
+                <ui-select-option
+                  *ngFor="let subField of field.fields"
+                  [value]="field.name + '.' + subField.name"
+                >
+                  {{
+                    field.name === '$attribute'
+                      ? subField.text || subField.name
+                      : field.name + ' - ' + (subField.text || subField.name)
+                  }}
+                </ui-select-option>
+              </ui-select-option>
+            </ng-container>
+          </ui-select-menu>
+        </div>
+      </div>
+
+      <ui-divider class="my-3"></ui-divider>
       <h3>
         {{
           'components.widget.settings.map.layers.popup.popupElements'

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
@@ -43,7 +43,6 @@
           ></ui-icon>
         </div>
       </div>
-
       <ui-toggle [formControlName]="navigateOptions.name">
         <ng-container ngProjectAs="label">
           {{ navigateOptions.text | translate
@@ -120,7 +119,6 @@
           </ui-select-menu>
         </div>
       </div>
-
       <ui-divider class="my-3"></ui-divider>
       <h3>
         {{

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
@@ -12,6 +12,9 @@ import { INLINE_EDITOR_CONFIG } from '../../../../../const/tinymce.const';
 import { EditorService } from '../../../../../services/editor/editor.service';
 import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.component';
 import { DomPortal } from '@angular/cdk/portal';
+import { ApplicationService } from '../../../../../services/application/application.service';
+import { Application } from '../../../../../models/application.model';
+import { ContentType, Page } from '../../../../../models/page.model';
 
 /**
  * Map layer popup settings component.
@@ -31,10 +34,20 @@ export class LayerPopupComponent
   @Input() mapPortal?: DomPortal;
   /** Available fields */
   @Input() fields$!: Observable<Fields[]>;
-  /** Keys for editor */
-  public keys: { text: string; value: string }[] = [];
+  public fields: any[] = [];
   /** Editor configuration */
   public editorConfig = INLINE_EDITOR_CONFIG;
+
+  /** Available pages from the application */
+  public pages: any[] = [];
+  /** Grid actions */
+  public navigateOptions = {
+    name: 'navigateToPage',
+    text: 'components.widget.settings.grid.actions.navigateToPage',
+    tooltip: 'components.widget.settings.grid.hint.actions.navigateToPage',
+  };
+  /** Show select page id and checkbox for record id */
+  public showSelectPage = false;
 
   /** @returns popup elements as form array */
   get popupElements(): FormArray {
@@ -46,22 +59,35 @@ export class LayerPopupComponent
    *
    * @param editorService Shared tinymce editor service.
    */
-  constructor(private editorService: EditorService) {
+  constructor(
+    private editorService: EditorService,
+    public applicationService: ApplicationService
+  ) {
     super();
   }
 
   ngOnInit(): void {
     // Listen to fields changes
     this.fields$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
-      this.keys = value.map((field) => ({
+      this.fields = value;
+      const keys = value.map((field) => ({
         text: `{{${field.name}}}`,
         value: `{{${field.name}}}`,
       }));
-      this.editorService.addCalcAndKeysAutoCompleter(
-        this.editorConfig,
-        this.keys
-      );
+      this.editorService.addCalcAndKeysAutoCompleter(this.editorConfig, keys);
     });
+
+    // Add available pages to the list of available keys
+    const application = this.applicationService.application.getValue();
+    this.pages = this.getPages(application);
+
+    this.showSelectPage = this.formGroup.get('navigateToPage')?.value;
+    this.formGroup
+      .get('navigateToPage')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((val: boolean) => {
+        this.showSelectPage = val;
+      });
   }
 
   /**
@@ -93,5 +119,35 @@ export class LayerPopupComponent
    */
   public onRemoveElement(index: number): void {
     this.popupElements.removeAt(index);
+  }
+
+  /**
+   * Get available pages from app
+   *
+   * @param application application
+   * @returns list of pages and their url
+   */
+  private getPages(application: Application | null) {
+    return (
+      application?.pages?.map((page: any) => ({
+        id: page.id,
+        name: page.name,
+        urlParams: this.getPageUrlParams(application, page),
+        placeholder: `{{page(${page.id})}}`,
+      })) || []
+    );
+  }
+
+  /**
+   * Get page url params
+   *
+   * @param application application
+   * @param page page to get url from
+   * @returns url of the page
+   */
+  private getPageUrlParams(application: Application, page: Page): string {
+    return page.type === ContentType.form
+      ? `${application.id}/${page.type}/${page.id}`
+      : `${application.id}/${page.type}/${page.content}`;
   }
 }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
@@ -37,7 +37,6 @@ export class LayerPopupComponent
   public fields: any[] = [];
   /** Editor configuration */
   public editorConfig = INLINE_EDITOR_CONFIG;
-
   /** Available pages from the application */
   public pages: any[] = [];
   /** Grid actions */
@@ -57,7 +56,8 @@ export class LayerPopupComponent
   /**
    * Creates an instance of LayerPopupComponent.
    *
-   * @param editorService Shared tinymce editor service.
+   * @param editorService Shared tinymce editor service
+   * @param applicationService Shared application service
    */
   constructor(
     private editorService: EditorService,

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.module.ts
@@ -15,6 +15,8 @@ import {
   IconModule,
   MenuModule,
   TooltipModule,
+  ToggleModule,
+  SelectMenuModule,
 } from '@oort-front/ui';
 import { PortalModule } from '@angular/cdk/portal';
 
@@ -40,6 +42,8 @@ import { PortalModule } from '@angular/cdk/portal';
     EditorControlComponent,
     TooltipModule,
     PortalModule,
+    ToggleModule,
+    SelectMenuModule,
   ],
   exports: [LayerPopupComponent],
 })

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -434,6 +434,11 @@ export const createPopupInfoForm = (value: any) =>
         createFieldsInfoForm(element)
       )
     ),
+    navigateToPage: get(value, 'navigateToPage', false),
+    navigateSettings: fb.group({
+      pageUrl: [get(value, 'navigateSettings.pageUrl', '')],
+      field: [get(value, 'navigateSettings.field', '')],
+    }),
   });
 
 /**

--- a/libs/shared/src/lib/models/layer.model.ts
+++ b/libs/shared/src/lib/models/layer.model.ts
@@ -120,6 +120,11 @@ export interface PopupInfo {
   description?: string;
   popupElements?: PopupElement[];
   fieldsInfo?: Fields[];
+  navigateToPage?: boolean;
+  navigateSettings?: {
+    field: string;
+    pageUrl: string;
+  };
 }
 
 export type LayerDatasourceType = 'Point' | 'Polygon';

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -293,6 +293,9 @@ export class FormBuilderService {
       }
     }
 
+    // Set query params as variables
+    this.formHelpersService.addQueryParamsVariables(survey);
+
     survey.showNavigationButtons = 'none';
     survey.showProgressBar = 'off';
     survey.focusFirstQuestionAutomatic = false;

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -294,7 +294,7 @@ export class FormBuilderService {
     }
 
     // Set query params as variables
-    this.formHelpersService.addQueryParamsVariables(survey);
+    this.formHelpersService.addQueryParamsVariables();
 
     survey.showNavigationButtons = 'none';
     survey.showProgressBar = 'off';

--- a/libs/shared/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/shared/src/lib/services/form-helper/form-helper.service.ts
@@ -702,7 +702,7 @@ export class FormHelpersService {
    *
    * @param survey Survey instance
    */
-  public addQueryParamsVariables = (survey: SurveyModel) => {
+  public addQueryParamsVariables = () => {
     const queryParams = this.router.parseUrl(this.router.url).queryParams;
     console.log('queryParams', queryParams);
   };

--- a/libs/shared/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/shared/src/lib/services/form-helper/form-helper.service.ts
@@ -31,6 +31,7 @@ import { WorkflowService } from '../workflow/workflow.service';
 import { ApplicationService } from '../application/application.service';
 import { DomService } from '../dom/dom.service';
 import { TemporaryFilesStorage } from '../form-builder/form-builder.service';
+import { Router } from '@angular/router';
 
 /**
  * Applies custom logic to survey data values.
@@ -93,6 +94,7 @@ export class FormHelpersService {
    * @param workflowService Shared workflow service
    * @param applicationService Shared application service
    * @param domService Shared dom service
+   * @param router Angular router service.
    */
   constructor(
     @Inject('environment') private environment: any,
@@ -104,7 +106,8 @@ export class FormHelpersService {
     private downloadService: DownloadService,
     private workflowService: WorkflowService,
     private applicationService: ApplicationService,
-    private domService: DomService
+    private domService: DomService,
+    private router: Router
   ) {}
 
   /**
@@ -691,5 +694,16 @@ export class FormHelpersService {
 
     // After the workflow context is set, we clear it
     this.workflowService.setContext([]);
+  };
+
+  /**
+   * Adds any query parameters to the survey variables
+   * These variables are accessible using the variables {queryParam.<paramName>}
+   *
+   * @param survey Survey instance
+   */
+  public addQueryParamsVariables = (survey: SurveyModel) => {
+    const queryParams = this.router.parseUrl(this.router.url).queryParams;
+    console.log('queryParams', queryParams);
   };
 }

--- a/libs/shared/src/lib/services/map/graphql/queries.ts
+++ b/libs/shared/src/lib/services/map/graphql/queries.ts
@@ -100,6 +100,11 @@ export const GET_LAYER_BY_ID = gql`
           description
           fields
         }
+        navigateToPage
+        navigateSettings {
+          field
+          pageUrl
+        }
       }
       sublayers
       contextFilters

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -6,7 +6,6 @@ import { ButtonComponent } from '@oort-front/ui';
 import { IconComponent } from '@oort-front/ui';
 import {
   CustomWidgetCollection,
-  ItemValue,
   JsonMetadata,
   Serializer,
   SurveyModel,
@@ -21,7 +20,6 @@ import {
 } from '../components/utils/create-picker-instance';
 import { TranslateService } from '@ngx-translate/core';
 import { FieldSearchTableComponent } from '../components/field-search-table/field-search-table.component';
-import { cloneDeep } from 'lodash';
 
 /**
  * Custom definition for overriding the text question. Allowed support for dates.


### PR DESCRIPTION
# Description

I added the possibility to include a button to popup to navigate to a different page. It is based on the logic used by grids. As there are to many differences in the use cases, I thought it was not relevant to create a seperate component to handle the logic.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-242)
- [Please insert link to back-end branch if any](https://github.com/ReliefApplications/oort-backend/pull/34)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I created a map and configured a layer that allows navigation through the popup. I checked the behavior when clicking on the corresponding button.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/2c2de62f-785a-4e50-a325-a86ea79cd0d7)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
