### PR TITLE
Fix/hit 254 form error in workflow

### DIFF
--- a/apps/front-office/src/app/application/pages/form/form.component.ts
+++ b/apps/front-office/src/app/application/pages/form/form.component.ts
@@ -145,7 +145,7 @@ export class FormComponent extends UnsubscribeComponent implements OnInit {
    * Handles the response for the given form query response data and loading state
    *
    * @param {FormQueryResponse} data data retrieved from the form query
-   * @param {boolean} loading loadin state
+   * @param {boolean} loading loading state
    */
   private handleApplicationLoadResponse(
     data: FormQueryResponse,
@@ -154,18 +154,23 @@ export class FormComponent extends UnsubscribeComponent implements OnInit {
     if (data) {
       this.form = data.form;
     }
-    if (
-      !this.form ||
-      this.form.status !== 'active' ||
-      !this.form.canCreateRecords
-    ) {
+
+    const displayError = (error: string) => {
       this.snackBar.openSnackBar(
-        this.translate.instant('common.notifications.accessNotProvided', {
+        this.translate.instant(error, {
           type: this.translate.instant('common.form.one').toLowerCase(),
           error: '',
         }),
         { error: true }
       );
+    };
+
+    if (!this.form) {
+      displayError('common.notifications.objectNotFound');
+    } else if (this.form.status !== 'active') {
+      displayError('common.notifications.formStatus');
+    } else if (!this.form.canCreateRecords) {
+      displayError('common.notifications.accessNotProvided');
     } else {
       this.canCreateRecords = true;
     }

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -261,6 +261,7 @@
 					"ready": "File uploaded"
 				}
 			},
+			"formStatus": "The current status of the form does not allow it to be displayed.",
 			"formatInvalid": "Please upload a valid .{{format}} file.",
 			"groups": {
 				"error": "Something went wrong trying to get groups from service",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -261,6 +261,7 @@
 					"ready": "Fichier importé"
 				}
 			},
+			"formStatus": "Le statut actuel du formulaire ne permet pas son affichage.",
 			"formatInvalid": "Veuillez importer un fichier de format .{{format}}.",
 			"groups": {
 				"error": "Une erreur s'est produite lors de la tentative d'obtenir des groupes du service",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -261,6 +261,7 @@
 					"ready": "******"
 				}
 			},
+			"formStatus": "******",
 			"formatInvalid": "****** {{format}} ******",
 			"groups": {
 				"error": "******",

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -6,7 +6,6 @@ import { ButtonComponent } from '@oort-front/ui';
 import { IconComponent } from '@oort-front/ui';
 import {
   CustomWidgetCollection,
-  ItemValue,
   JsonMetadata,
   Serializer,
   SurveyModel,
@@ -21,7 +20,6 @@ import {
 } from '../components/utils/create-picker-instance';
 import { TranslateService } from '@ngx-translate/core';
 import { FieldSearchTableComponent } from '../components/field-search-table/field-search-table.component';
-import { cloneDeep } from 'lodash';
 
 /**
  * Custom definition for overriding the text question. Allowed support for dates.


### PR DESCRIPTION
# Description

There was an error because the status of the form was set to `pending` instead of `active`. I added more errors messages, as three conditions were triggering the same message, which was a bit confusing.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-254)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I copied the pci db locally, changed the status of the form, and went through the different workflow steps.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/a6c55086-1b7b-46cc-b178-e0db5117df49)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
