### PR TITLE
Fix/hit 255 unable to resubmit aid form from ermergency

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -214,6 +214,10 @@ export class FormComponent
     this.formHelpersService.addUserVariables(this.survey);
     /** Force reload of the survey so default value are being applied */
     this.survey.fromJSON(this.survey.toJSON());
+    /** Adding variables */
+    this.formHelpersService.addUserVariables(this.survey);
+    this.formHelpersService.addApplicationVariables(this.survey);
+    this.formHelpersService.setWorkflowContextVariable(this.survey);
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });
     if (this.resetTimeoutListener) {


### PR DESCRIPTION
# Description

The form variables weren't reattributed when resetting the form.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-255)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to submit the form called "Urgence ou Maraude" and add a new record. I checked if the inputs were correctly initialized.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/1f593486-c0c0-422d-961a-0957117fee92)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
