### PR TITLE
Fix/hit 260 actions column too large in grid widgets

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1,2589 +1,2589 @@
 {
-  "common": {
-    "access": "Access",
-    "accessDenied": "Access denied",
-    "account": "Account",
-    "actions": "Actions",
-    "add": "Add",
-    "adminField": "Admin field",
-    "aggregation": {
-      "add": "Add aggregation",
-      "few": "Aggregations",
-      "none": "No aggregation",
-      "one": "Aggregation"
-    },
-    "apiConfiguration": {
-      "few": "API Configurations",
-      "none": "No API Configuration",
-      "one": "API Configuration"
-    },
-    "application": {
-      "few": "Applications",
-      "none": "No application",
-      "one": "Application"
-    },
-    "archive": {
-      "delete": "Delete",
-      "few": "Archive",
-      "modal": {
-        "delete": {
-          "action": "Delete",
-          "confirmationMessage": "Do you want to delete archived page: {{name}}?",
-          "title": "Delete?"
-        },
-        "restore": {
-          "action": "Restore",
-          "confirmationMessage": "Do you want to restore the archived page: {{name}}?",
-          "title": "Restore?"
-        }
-      },
-      "none": "No archived items",
-      "restore": "Restore"
-    },
-    "ariaLabel": {
-      "search": {
-        "clear": "Clear search"
-      }
-    },
-    "asc": "Ascending",
-    "attribute": {
-      "few": "Attributes",
-      "none": "No attribute",
-      "one": "Attribute"
-    },
-    "auto": "Auto",
-    "back": "Back",
-    "bookmarks": "Bookmarks",
-    "calculatedField": {
-      "few": "Calculated Fields",
-      "none": "No Calculated field",
-      "one": "calculated Field"
-    },
-    "cancel": "Cancel",
-    "channel": {
-      "few": "Channels",
-      "none": "No channel",
-      "one": "Channel"
-    },
-    "child": {
-      "edit": "Edit child",
-      "one": "Child"
-    },
-    "clear": "Clear",
-    "close": "Close",
-    "column": {
-      "few": "Columns",
-      "none": "No column",
-      "one": "Column"
-    },
-    "comma": "comma",
-    "copy": "Copy",
-    "create": "Create",
-    "createdOn": "Created on",
-    "cronEditor": {
-      "advanced": "Advanced",
-      "atTime": "At",
-      "daily": "Daily",
-      "day": "Day",
-      "days": "Day(s)",
-      "every": {
-        "feminine": "Every",
-        "masculine": "Every"
-      },
-      "firstWeekDay": "First week day",
-      "hourly": "Hourly",
-      "hours": "Hour(s)",
-      "lastDay": "Last day",
-      "lastWeekDay": "Last week day",
-      "minutely": "Minutely",
-      "minutes": "Minute(s)",
-      "month": "Month",
-      "monthly": "Monthly",
-      "months": {
-        "april": "April",
-        "august": "August",
-        "december": "December",
-        "february": "February",
-        "january": "January",
-        "july": "July",
-        "june": "June",
-        "march": "March",
-        "may": "May",
-        "november": "November",
-        "october": "October",
-        "september": "September"
-      },
-      "of": "of",
-      "ofEvery": "of every",
-      "onThe": {
-        "feminine": "On the",
-        "masculine": "On the"
-      },
-      "seconds": "Second(s)",
-      "week": "Week",
-      "weekDay": "Week Day (MON-FRI)",
-      "weekDays": {
-        "friday": "Friday",
-        "monday": "Monday",
-        "saturday": "Saturday",
-        "sunday": "Sunday",
-        "thursday": "Thursday",
-        "tuesday": "Tuesday",
-        "wednesday": "Wednesday"
-      },
-      "weekNumber": {
-        "fifth": "Fifth",
-        "first": "First",
-        "fourth": "Fourth",
-        "last": "Last",
-        "second": "Second",
-        "third": "Third"
-      },
-      "weekly": "Weekly",
-      "yearly": "Yearly"
-    },
-    "customNotification": {
-      "few": "Custom notifications",
-      "none": "No Custom notification",
-      "one": "Custom notification"
-    },
-    "dashboard": {
-      "few": "Dashboards",
-      "none": "No dashboard",
-      "one": "Dashboard"
-    },
-    "delete": "Delete",
-    "deleteObject": "Delete {{name}}",
-    "deleted": "Deleted",
-    "desc": "Descending",
-    "dismiss": "Dismiss",
-    "display": "Display",
-    "distributionList": {
-      "few": "Distribution lists",
-      "none": "No distribution list",
-      "one": "Distribution list"
-    },
-    "downloadObject": "Download {{name}}",
-    "downloadTemplate": "Get template",
-    "duplicate": "Duplicate",
-    "edit": "Edit",
-    "email": {
-      "few": "Emails",
-      "none": "No email",
-      "one": "Email"
-    },
-    "errors": {
-      "few": "Errors",
-      "objectDuplicated": "{{type}} {{value}} already exists."
-    },
-    "exitFullscreen": "Exit Fullscreen",
-    "export": "Export",
-    "exportObject": "Export {{name}}",
-    "false": "False",
-    "field": {
-      "few": "Fields",
-      "none": "No field",
-      "one": "Field"
-    },
-    "filter": {
-      "apply": "Apply",
-      "clear": "Clear Filter",
-      "empty": "No result",
-      "few": "Filters",
-      "hide": "Hide Filter",
-      "none": "No filter",
-      "one": "Filter",
-      "show": "Show Filter"
-    },
-    "form": {
-      "few": "Forms",
-      "none": "No form",
-      "one": "Form"
-    },
-    "general": "General",
-    "group": {
-      "few": "Groups",
-      "none": "No groups",
-      "one": "Group"
-    },
-    "hide": "Hide",
-    "history": "History",
-    "id": "Id",
-    "input": {
-      "dateRange": "Date range",
-      "none": "-- None --",
-      "rawJson": "Raw JSON"
-    },
-    "label": "Label",
-    "layers": {
-      "few": "Layers",
-      "none": "No layer"
-    },
-    "layout": {
-      "few": "Layouts",
-      "none": "No layout",
-      "one": "Layout"
-    },
-    "loading": "Loading",
-    "modifiedOn": "Modified On",
-    "name": "Name",
-    "next": "Next",
-    "noOptions": "No available choices",
-    "notifications": {
-      "accessDenied": "You don't have permission to see the {{type}}.",
-      "accessNotProvided": "No access provided to this {{type}}. {{error}}",
-      "alreadyExists": "The {{type}} {{value}} already exists on this application.",
-      "copiedToClipboard": "Dashboard link copied!",
-      "dataNotRecovered": "Failure on data recovery",
-      "dataRecovered": "The data has been recovered",
-      "email": {
-        "error": "Something went wrong during the email sending",
-        "errors": {
-          "noDistributionList": "Something went wrong during the email sending: no distribution list found",
-          "noTemplate": "Something went wrong during the email sending: no template found"
-        },
-        "processing": "Sending email...",
-        "ready": "Email ready",
-        "sent": "Email sent"
-      },
-      "fetchingGroups": "Fetching groups from service...",
-      "file": {
-        "download": {
-          "error": "Something went wrong during the download",
-          "ongoing": "Your file export is ongoing. You will receive an email once ready.",
-          "processing": "Downloading file...",
-          "ready": "Your file is ready"
-        },
-        "upload": {
-          "error": "Something went wrong during the upload",
-          "maxFileSize": "Maximum file size is {{size}} MB.",
-          "processing": "Uploading file...",
-          "ready": "File uploaded"
-        }
-      },
-      "formStatus": "The current status of the form does not allow it to be displayed.",
-      "formatInvalid": "Please upload a valid .{{format}} file.",
-      "groups": {
-        "error": "Something went wrong trying to get groups from service",
-        "processing": "Fetching groups from service...",
-        "ready": "Groups fetched"
-      },
-      "history": {
-        "error": "Something went wrong during the history generation. {{error}}"
-      },
-      "loadedFromCache": "{{type}} loaded from cache.",
-      "noOpened": "No opened {{value}}.",
-      "objectCreated": "{{value}} {{type}} was successfully created.",
-      "objectDeleted": "{{value}} was successfully deleted.",
-      "objectDuplicated": "{{type}} {{value}} was successfully duplicated.",
-      "objectInvited": "{{name}} invited.",
-      "objectLocked": "{{name}} edition is locked by another user.",
-      "objectNotCreated": "The {{type}} was not created. {{error}}",
-      "objectNotDeleted": "{{value}} deletion failed. {{error}}",
-      "objectNotDuplicated": "The {{type}} was not duplicated. {{error}}",
-      "objectNotFound": "{{name}} not found.",
-      "objectNotInvited": "{{name}} invitation failed.",
-      "objectNotReordered": "{{type}} not reordered. {{error}}",
-      "objectNotRestored": "{{value}} not restored. {{error}}",
-      "objectNotUpdated": "{{type}} not edited. {{error}}",
-      "objectReordered": "{{type}} reordered.",
-      "objectRestored": "{{value}} restored.",
-      "objectUpdated": "{{value}} {{type}} was successfully edited.",
-      "platformAccessNotGranted": "You don't have a valid access to this platform.",
-      "readAll": "Mark all as read",
-      "statusUpdated": "Status updated to {{value}}.",
-      "unlocked": "{{name}} edition has been unlocked by another user."
-    },
-    "openFullScreen": "Open in Full Screen",
-    "options": "Options",
-    "or": "Or",
-    "page": {
-      "few": "Pages",
-      "none": "No page",
-      "one": "Page"
-    },
-    "pagination": {
-      "empty": "No result",
-      "itemsPerPage": "Items per page",
-      "loadMore": "Load more",
-      "of": "of"
-    },
-    "placeholder": {
-      "address": "Enter an address or place e.g. 1 York St",
-      "email": "Enter email",
-      "name": "Enter a name",
-      "search": "Search...",
-      "title": "Enter a title"
-    },
-    "platform": {
-      "backOffice": "Back-Office"
-    },
-    "position": {
-      "bottomleft": "Bottom left",
-      "bottomright": "Bottom right",
-      "topleft": "Top left",
-      "topright": "Top right"
-    },
-    "positionAttribute": {
-      "few": "Position attributes",
-      "none": "No position attribute",
-      "one": "Position attribute"
-    },
-    "positionCategory": {
-      "few": "Position categories",
-      "none": "No position category",
-      "one": "Position category"
-    },
-    "preview": "Preview",
-    "previous": "Previous",
-    "publish": "Publish",
-    "pullJob": {
-      "few": "Pull jobs",
-      "none": "No pull job",
-      "one": "Pull job"
-    },
-    "record": {
-      "few": "Records",
-      "none": "No record",
-      "one": "Record"
-    },
-    "referenceData": {
-      "few": "Reference Data",
-      "none": "No Reference Data",
-      "one": "Reference Data"
-    },
-    "remove": "Remove",
-    "resource": {
-      "few": "Resources",
-      "none": "No resource",
-      "one": "Resource"
-    },
-    "role": {
-      "few": "Roles",
-      "none": "No role",
-      "one": "Role"
-    },
-    "row": {
-      "few": "Rows",
-      "none": "No row",
-      "one": "Row",
-      "update": {
-        "few": {
-          "content": "Do you really want to update {{quantity}} rows?",
-          "title": "Update rows"
-        },
-        "one": {
-          "content": "Do you really want to update this row?",
-          "title": "Update row"
-        }
-      }
-    },
-    "save": "Save",
-    "saveChanges": "Save changes",
-    "search": "Search",
-    "searchObject": "Search {{name}}",
-    "select": "Select",
-    "selectStatus": "Select a status",
-    "semicolon": "semicolon",
-    "send": "Send",
-    "separator": "Separator",
-    "settings": "Settings",
-    "status": "Status",
-    "status_active": "Active",
-    "status_archived": "Archived",
-    "status_pending": "Pending",
-    "step": {
-      "few": "Steps",
-      "none": "No step",
-      "one": "Step"
-    },
-    "subscription": {
-      "few": "Subscriptions",
-      "none": "No subscription",
-      "one": "Subscription"
-    },
-    "tabs": "Tabs",
-    "template": {
-      "few": "Notification templates",
-      "none": "No template",
-      "one": "Notification template"
-    },
-    "title": "Title",
-    "tooltip": {
-      "dragDrop": "Drag and drop to reorder",
-      "editor": {
-        "insert": "Type '{' to inject expressions and variables"
-      }
-    },
-    "true": "True",
-    "type": {
-      "few": "Types",
-      "none": "No type",
-      "one": "Type"
-    },
-    "update": "Update",
-    "updateObject": "Update {{name}}",
-    "uploadObject": "Upload {{name}}",
-    "user": {
-      "few": "Users",
-      "none": "No user",
-      "one": "User"
-    },
-    "value": {
-      "few": "Values",
-      "none": "No value",
-      "one": "Value"
-    },
-    "viewFullscreen": "View Fullscreen",
-    "viewObject": "View {{name}}",
-    "workflow": {
-      "few": "Workflows",
-      "none": "No workflow",
-      "one": "Workflow"
-    }
-  },
-  "components": {
-    "access": {
-      "canDelete": "Can delete",
-      "canSee": "Can see",
-      "canUpdate": "Can update",
-      "description": "Update {{name}} permissions",
-      "title": "Access"
-    },
-    "aggregation": {
-      "add": {
-        "choice": {
-          "create": "Create a new aggregation",
-          "load": "Load existing aggregation"
-        },
-        "select": "Select an aggregation",
-        "title": "Add new aggregation"
-      },
-      "edit": {
-        "title": "Aggregation configuration"
-      }
-    },
-    "aggregationBuilder": {
-      "accumulators": "Accumulators",
-      "addField": "Add field",
-      "addRule": "Add rule",
-      "addStage": "Add stage",
-      "dataset": {
-        "select": "Select the data source"
-      },
-      "fieldName": "Field name",
-      "groupBy": "Group by",
-      "groupingRules": "Grouping rules",
-      "mapping": {
-        "category": "Category",
-        "field": "Value",
-        "series": "Series"
-      },
-      "operator": "Operator",
-      "operators": {
-        "add": "Add",
-        "avg": "Average",
-        "count": "Count",
-        "day": "Day",
-        "first": "First",
-        "last": "Last",
-        "max": "Maximum",
-        "min": "Minimum",
-        "month": "Month",
-        "multiply": "Multiply",
-        "sum": "Sum",
-        "week": "Week",
-        "year": "Year"
-      },
-      "preview": {
-        "hide": "Hide preview",
-        "show": "Show preview"
-      },
-      "sourceFields": "Select fields",
-      "stages": {
-        "addFields": "Add fields",
-        "custom": "Custom",
-        "filter": "Filter",
-        "group": "Group & Accumulator",
-        "sort": "Sort",
-        "unwind": "Unwind"
-      },
-      "tooltip": {
-        "addFields": "Adds new fields to documents.",
-        "custom": "Defines a custom aggregation function or expression in JavaScript.",
-        "filter": "Returns an array with only those elements that match the condition.",
-        "group": "Group records based on field values and construct personalized accumulators",
-        "groupingRules": "Grouping rules are optional.",
-        "selectedFields": "Only unused fields can be removed.",
-        "sort": "Sorts all input documents and returns them to the pipeline in sorted order.\nEstablishing consecutive sorting stages will simultaneously sort all fields.",
-        "unwind": "Deconstructs an array field from the input documents to output a document for each element."
-      }
-    },
-    "apiConfiguration": {
-      "create": {
-        "errors": {
-          "name": "Invalid name: please only use letters, digits and underscores."
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the API Configuration {{name}}?",
-        "title": "Delete API configuration"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of API configurations"
-      }
-    },
-    "application": {
-      "archive": {
-        "autoDeletedAt": "Automatically removed on",
-        "name": "Name"
-      },
-      "customStyling": "Custom Styling",
-      "dashboard": {
-        "clearFields": "Clear fields",
-        "editFilter": "Edit filter",
-        "empty": "No content available. Wait for your administrator to build some.",
-        "enterEditMode": "Enter edit mode",
-        "enterPreviewMode": "Enter preview mode",
-        "filter": {
-          "empty": "No filters have been defined by the administrators",
-          "filterPosition": {
-            "bottom": "Show filter on the bottom",
-            "left": "Show filter on the left",
-            "right": "Show filter on the right",
-            "top": "Show filter on the top",
-            "unset": "Position unset, please select one"
-          },
-          "info": "Dashboard filters can be used between pages to filter their content.",
-          "title": "Dashboard filters configuration"
-        },
-        "filterSettings": "Filter settings",
-        "settings": {
-          "defaultPosition": "Default position for the filter",
-          "fixedRowHeight": "Row height",
-          "gridOptions": "Grid options",
-          "gridType": {
-            "fit": "Fit",
-            "placeholder": "Select a grid type",
-            "title": "Grid type",
-            "verticalFixed": "Vertical fixed"
-          },
-          "help": {
-            "minCols": "Reducing the number of columns may not have a direct impact if the dashboard contains widgets wider than the specified limit."
-          },
-          "margin": "Margin between widgets",
-          "minCols": "Number of columns",
-          "minimumHeight": "Minimum height",
-          "tooltip": {
-            "fixedRowHeight": "Size of rows in pixels.\nMust be greater or equal to 50.",
-            "margin": "Gap in pixels between widgets.\nMust be a positive integer.",
-            "minCols": "Number of columns.\nMust be an integer between 4 and 24.",
-            "minimumHeight": "Minimum height of the grid in pixels.\nMust be greater than or equal to 0. \nThe dashboard won't automatically fit to the screen if its height is below this number.",
-            "reset": "Reset to default"
-          }
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the application {{name}}?"
-      },
-      "duplicate": {
-        "name": {
-          "description": "Please enter a description for the application"
-        }
-      },
-      "pages": {
-        "delete": {
-          "confirmationMessage": "Do you confirm the deletion of the page {{name}}?"
-        },
-        "hide": "Hide page in nav bar for end-users",
-        "notReordered": {
-          "plural": "The pages were not reordered. {{error}}",
-          "singular": "The page was not reordered. {{error}}"
-        },
-        "reordered": {
-          "plural": "The pages were successfully reordered.",
-          "singular": "The page was successfully reordered."
-        },
-        "settings": {
-          "actions": "Actions",
-          "goNextStepOnSave": "Go to next step on save",
-          "selectIcon": "Select an icon",
-          "tooltip": {
-            "autoSave": "Changes are automatically saved"
-          }
-        },
-        "show": "Make page visible in nav bar for end-users"
-      },
-      "positionAttribute": {
-        "delete": {
-          "confirmationMessage": "Do you confirm the deletion of the position attribute {{name}}?",
-          "title": "Delete position attribute"
-        }
-      },
-      "publish": {
-        "confirmationMessage": "Do you confirm the publication of {{name}} application?",
-        "title": "Publish application"
-      },
-      "subscription": {
-        "modal": {
-          "hint": {
-            "listenTo": "Message broker routing key"
-          },
-          "listenTo": "Listen to",
-          "placeholder": {
-            "listenTo": "Select a routing key"
-          },
-          "routingKey": {
-            "clear": {
-              "ariaLabel": "Clear routing key"
-            }
-          }
-        }
-      },
-      "unlock": {
-        "confirmationMessage": "Do you want to unlock edition of {{name}}?",
-        "title": "Unlock edition"
-      },
-      "update": {
-        "hideMenu": "Hide menu by default",
-        "placeholder": {
-          "description": "Please enter a description for the application"
-        },
-        "sideMenu": "Show menu on the side",
-        "tooltip": {
-          "hideMenu": "Only applies when menu is located on the side"
-        }
-      },
-      "users": {
-        "auto": "Automatically assigned",
-        "empty": "No user detected",
-        "manual": "Manually assigned"
-      }
-    },
-    "applications": {
-      "dropdown": {
-        "select": "From applications"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of applications"
-      }
-    },
-    "calculatedFields": {
-      "add": "Create a new Calculated field",
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the Calculated field {{name}}?"
-      },
-      "edit": "Edit Calculated field",
-      "expression": "Expression",
-      "hint": {
-        "name": "Enter an unique name only composed of letters, digits and underscores. This name should not override any field name of current resource."
-      }
-    },
-    "channel": {
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the channel {{name}}?"
-      },
-      "dropdown": {
-        "select": "Notify on"
-      },
-      "selectChannel": "Select a channel"
-    },
-    "confirmModal": {
-      "cancel": "Cancel",
-      "confirm": "Confirm",
-      "delete": "Delete",
-      "title": "Confirm"
-    },
-    "customNotifications": {
-      "edit": {
-        "dataset": "Dataset",
-        "email": "Email notification",
-        "new": "New custom Notification",
-        "recipients": {
-          "distributionList": "Use a distribution list",
-          "email": "Input a single email address",
-          "title": "Recipients",
-          "userField": "Group by dataset user field"
-        },
-        "update": "Edit custom notification"
-      },
-      "errors": {
-        "email": "Please input a valid email address",
-        "schedule": "Enter a valid cron expression"
-      },
-      "hint": {
-        "schedule": "Enter schedule for notification sending"
-      }
-    },
-    "distributionLists": {
-      "delete": {
-        "confirmationMessage": "Are you sure you want to delete the distribution list '{{name}}'?"
-      },
-      "edit": {
-        "name": "Distribution list name",
-        "new": "New distribution list",
-        "update": "Edit distribution list"
-      },
-      "errors": {
-        "emails": {
-          "pattern": "Please only provide valid emails",
-          "required": "Please provide one or more emails"
-        },
-        "name": {
-          "required": "Please provide a name"
-        }
-      }
-    },
-    "emailBuilder": {
-      "body": "Body",
-      "default": "Default",
-      "fields": "Select fields to write in body",
-      "from": {
-        "distribution": "Distribution list",
-        "field": "Data field",
-        "title": "From:"
-      },
-      "subject": "Subject",
-      "withoutRecords": "Without records"
-    },
-    "emailPreview": {
-      "errors": {
-        "missingSubject": "The subject of the email cannot be empty."
-      },
-      "from": "From",
-      "subject": "Subject",
-      "title": "Email preview",
-      "to": "To"
-    },
-    "form": {
-      "aggregation": {
-        "delete": {
-          "confirmationMessage": "Do you confirm the deletion of the aggregation {{name}}?"
-        }
-      },
-      "create": {
-        "choice": {
-          "inherit": "Create from template",
-          "resource": "Create a core form",
-          "template": "Start from existing template"
-        },
-        "template": {
-          "from": "From template",
-          "placeholder": "Pick an existing template",
-          "selectResource": "Select a resource",
-          "title": "From resource"
-        },
-        "tooltip": {
-          "inherit": "Creates a child form using a template from the resource linked to the core form",
-          "resource": "Creates a core form that allows the creation of children forms linked to this core form. It will also create a new resource.",
-          "template": "If no template is selected, core structure will be loaded"
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the form {{name}}?"
-      },
-      "deleteRow": {
-        "confirmationMessage": "Do you confirm the deletion of {{quantity}} {{rowText}}?"
-      },
-      "display": {
-        "submissionMessage": "The form has successfully been submitted."
-      },
-      "draftRecords": {
-        "buttonLoad": "Load draft record",
-        "confirmModal": {
-          "confirmDelete": "Do you really want to delete this draft record?",
-          "confirmLoad": "Do you really want to load this draft record?",
-          "delete": "Delete this draft",
-          "load": "Load this draft"
-        },
-        "creationDate": "Creation date",
-        "delete": "Delete this draft",
-        "load": "Load this draft",
-        "noDrafts": "No draft available.",
-        "preview": "Preview this draft",
-        "previewTitle": "Draft record",
-        "save": "Save as draft",
-        "select": "Select draft record",
-        "successEdit": "Successfully edited draft",
-        "successSave": "Successfully saved as draft"
-      },
-      "layout": {
-        "delete": {
-          "confirmationMessage": "Do you confirm the deletion of the layout {{name}}?"
-        },
-        "errors": {
-          "invalid": "The form is not valid"
-        },
-        "update": {
-          "preview": {
-            "description": "Reorder, sort, filter and hide columns to edit default display of the layout"
-          }
-        }
-      },
-      "searchExistingRecords": {
-        "matches": "Matches",
-        "noMatches": "No matches found",
-        "openRecordTooltip": "Open record"
-      },
-      "summary": {
-        "cache": {
-          "clear": "Clear cache",
-          "load": "Load from cache {{date}}"
-        },
-        "createdBy": "Created by {{user}} at {{date}}",
-        "modifiedBy": "Last modified by {{user}} on {{date}}"
-      },
-      "update": {
-        "exit": "Exit without saving changes",
-        "exitMessage": "There are unsaved changes on your form. Are you sure you want to exit?"
-      },
-      "updateRow": {
-        "confirmationMessage": "Do you confirm the update of {{quantity}} {{rowText}}?"
-      }
-    },
-    "formBuilder": {
-      "errors": {
-        "duplicatedRelatedName": "Duplicated related name for question {{question}} on page {{page}}. Please provide a unique related name (snake case format) to save the form.",
-        "incorrectJSON": "JSON is invalid in JSON Editor, changes haven't been saved",
-        "missingGridField": "Missing an available field grid for question {{question}} on page {{page}}. Please select a least one in Custom Question Properties to save the form.",
-        "missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",
-        "missingTemplate": "Missing related resource template for question {{question}} on page {{page}}. Please select a template to save the form."
-      },
-      "propertyGrid": {
-        "resource": {
-          "availableGridFields": "Available grid fields",
-          "resourceSelectText": "First you have to select a resource before setting any filters"
-        }
-      },
-      "saveSurvey": "Saving the form"
-    },
-    "formMapProperties": {
-      "geofields": {
-        "editDialog": {
-          "editGeofield": "Edit Geo fields",
-          "label": "Label",
-          "value": "Value"
-        }
-      }
-    },
-    "forms": {
-      "isCore": "Is core",
-      "paginator": {
-        "ariaLabel": "Select page of forms"
-      },
-      "parent": "Parent form"
-    },
-    "group": {
-      "add": {
-        "title": "Add new group"
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the group {{name}}?",
-        "title": "Delete group"
-      }
-    },
-    "header": {
-      "goToApp": "Go to application",
-      "goToPlatform": "Navigate to",
-      "logout": "Logout",
-      "sidenav": {
-        "collapse": "Collapse sidebar",
-        "show": "Show sidebar"
-      }
-    },
-    "history": {
-      "changes": {
-        "add": "Add value",
-        "from": "from",
-        "modify": "Change value",
-        "remove": "Delete value",
-        "to": "to",
-        "withValue": "with value"
-      },
-      "columns": {
-        "action": "Action type",
-        "date": "Date",
-        "modifiedValue": "New value",
-        "originalValue": "Old value",
-        "person": "User",
-        "time": "Time",
-        "variable": "Field"
-      },
-      "download": "Download history",
-      "empty": "No activity detected",
-      "field": {
-        "all": "All fields",
-        "select": "Select fields"
-      },
-      "preview": "Preview and revert",
-      "range": {
-        "clear": "Clear range"
-      },
-      "useTableMode": "Use table mode"
-    },
-    "icon": {
-      "modal": {
-        "select": "Select an icon",
-        "use": "Use icon"
-      }
-    },
-    "logout": {
-      "confirmationMessage": "There are unsaved changes on your form. Are you sure you want to logout?",
-      "title": "Exit without saving changes"
-    },
-    "map": {
-      "controls": {
-        "download": {
-          "layers": {
-            "all": "All layers",
-            "selected": "Selected Layers",
-            "visible": "Visible layers"
-          },
-          "output": "Select an output format",
-          "selectLayers": "Select layers",
-          "view": {
-            "all": "Map",
-            "current": "Current view"
-          }
-        },
-        "timeline": {
-          "show": "Show timeline",
-          "time": {
-            "dateFormat": "Date display",
-            "startField": "Start showing at",
-            "stopField": "Stop showing at",
-            "tooltip": "When enabled, a timeline will be displayed on the map. It will allow you to visualize the evolution of your data over time."
-          },
-          "title": "Timeline"
-        }
-      }
-    },
-    "mapping": {
-      "field": "User field",
-      "path": "Path",
-      "text": "Text",
-      "title": "Mapping",
-      "value": "Value"
-    },
-    "notifications": {
-      "paginator": {
-        "ariaLabel": "Select page of notifications"
-      },
-      "readAll": "Mark all as read",
-      "title": "Notifications"
-    },
-    "paginator": {
-      "items": "items",
-      "itemsPerPage": "items per page",
-      "of": "of",
-      "page": "Page"
-    },
-    "preferences": {
-      "dateFormat": "Date and time format",
-      "language": "Language",
-      "title": "Preferences"
-    },
-    "pullJob": {
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the pull job {{name}}?",
-        "title": "Delete pull job"
-      },
-      "modal": {
-        "addMappingField": "add a mapping field",
-        "errors": {
-          "schedule": "Enter a valid cron expression"
-        },
-        "hint": {
-          "path": "Enter the path to extract data from response",
-          "schedule": "Enter the schedule time for this Pull job",
-          "url": "Enter the URL after the host to reach specific data"
-        },
-        "identifier": "Unique identifiers",
-        "mapping": "Mapping",
-        "placeholder": {
-          "path": "Enter path...",
-          "schedule": "Enter schedule time...",
-          "url": "Enter URL..."
-        },
-        "switch": "Switch mode"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of pull jobs"
-      }
-    },
-    "queryBuilder": {
-      "dataset": {
-        "select": "Select a dataset"
-      },
-      "errors": {
-        "field": {
-          "invalid": "Invalid field. Please click to remove."
-        }
-      },
-      "fields": {
-        "available": "Available fields",
-        "column": "Column width (px)",
-        "format": {
-          "info": "Left empty to ignore formatting",
-          "title": "Display format"
-        },
-        "search": "Search fields...",
-        "selected": "Selected fields",
-        "title": "Fields"
-      },
-      "filter": {
-        "and": "And",
-        "logic": "Filter logic",
-        "new": "Add new filter",
-        "newGroup": "Add new filter group",
-        "operator": "Operator",
-        "or": "Or",
-        "title": "Filter"
-      },
-      "hint": {
-        "fields": "Select data points below and drag them to 'selected fields' on the right",
-        "sortingDisabled": "Sorting fields is disabled when search is active",
-        "style": "Styling rules make records with important information stand out. When a record matches more than one rule, the first rule is used."
-      },
-      "pagination": {
-        "first": "Limit",
-        "title": "Pagination"
-      },
-      "sort": {
-        "ascending": "Ascending",
-        "descending": "Descending",
-        "field": "Sort field",
-        "limit": "limit",
-        "limitTitle": "Sort & Limit",
-        "order": "Sort order",
-        "title": "Sort"
-      },
-      "style": {
-        "and": "And",
-        "edit": {
-          "appliesTo": "Apply style to",
-          "background": {
-            "color": "Background color"
-          },
-          "criteria": "Rule criteria",
-          "fields": "Fields",
-          "name": "Rule name",
-          "selectedColumns": "Only selected columns",
-          "text": {
-            "color": "Text color",
-            "style": "Text style"
-          },
-          "wholeRow": "Whole row"
-        },
-        "logic": "Style filter",
-        "new": "Add styling rule",
-        "operator": "Operator",
-        "or": "Or",
-        "title": "Style"
-      },
-      "tooltip": {
-        "filter": {
-          "date": {
-            "useExpression": "Use Expression editor",
-            "usePicker": "Use Date picker"
-          }
-        },
-        "pagination": {
-          "first": "If provided, limit the number of queried items"
-        }
-      }
-    },
-    "record": {
-      "attach": {
-        "confirm": "Attach",
-        "selectTarget": "Select {{name}} target"
-      },
-      "convert": {
-        "choice": {
-          "copy": "Copy source record",
-          "overwrite": "Overwrite source record"
-        },
-        "result": {
-          "force": "Following fields will be ignored:",
-          "smooth": "Conversion OK"
-        },
-        "select": "Convert to"
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the record {{name}}?",
-        "permanently": "Delete permanently"
-      },
-      "dropdown": {
-        "select": "Select record"
-      },
-      "history": {
-        "revert": "Revert to past record",
-        "version": {
-          "current": "Current version",
-          "old": "Past version"
-        }
-      },
-      "modal": {
-        "closeConfirmation": "Close without saving changes?",
-        "update": "Save and close"
-      },
-      "recovery": {
-        "confirmationMessage": "Do you confirm recovery the data from {{date}} to the current register?",
-        "title": "Recovery data"
-      }
-    },
-    "records": {
-      "active": "Active records",
-      "archived": "Archived records",
-      "editAs": "Edit as",
-      "paginator": {
-        "ariaLabel": "Select page of records"
-      },
-      "showActive": "Show active records",
-      "showArchived": "Show archived records",
-      "upload": {
-        "hint": "File should contain one record per row. Header row contains the names of data fields."
-      }
-    },
-    "referenceData": {
-      "create": {
-        "title": "New Reference Data"
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of Reference Data {{name}}?",
-        "title": "Delete Reference Data"
-      },
-      "dropdown": {
-        "select": "From Reference data"
-      },
-      "fields": {
-        "add": "Add field",
-        "ariaLabel": "Input available fields of reference data",
-        "new": "New field"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of reference data"
-      }
-    },
-    "resource": {
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the resource {{name}}?"
-      },
-      "dropdown": {
-        "select": "From resource"
-      },
-      "empty": {
-        "aggregations": "No aggregation detected",
-        "calculatedFields": "No calculated fields detected",
-        "layouts": "No layout detected",
-        "records": "No record detected"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of resources"
-      }
-    },
-    "role": {
-      "add": {
-        "title": "Add new role"
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the role {{name}}?",
-        "title": "Delete role"
-      },
-      "impersonate": {
-        "title": "Choose role to simulate"
-      },
-      "summary": {
-        "addFilter": "Add filter",
-        "autoAssignment": {
-          "rule": {
-            "add": "Create assignment rule",
-            "delete": "Delete rule",
-            "edit": "Edit assignment rule",
-            "none": "No assignment rule",
-            "title": "Rule"
-          },
-          "title": "Automatic assignment"
-        },
-        "details": {
-          "access": {
-            "channels": "Channels access",
-            "fullAccess": "Full access to {{accessible}} / {{total}}",
-            "limitedAccess": "Limited access to {{accessible}} / {{total}}",
-            "noAccess": "No access to {{accessible}} / {{total}}",
-            "pages": "Pages access",
-            "resources": "Resources access",
-            "title": "Access summary"
-          }
-        },
-        "editFilters": "Edit filters",
-        "features": "Features",
-        "newFilter": "New filter",
-        "noFeatures": "No feature detected",
-        "noFilters": "No access filters detected",
-        "noForms": "No forms detected",
-        "noSteps": "No steps detected",
-        "removeFilter": "Remove filter",
-        "title": "Summary",
-        "users": {
-          "auto": "Automatically assigned",
-          "empty": "No user detected",
-          "manual": "Manually assigned"
-        }
-      },
-      "tooltip": {
-        "allowFieldAccessibility": "Allow this role to see the field {{field}}",
-        "allowFieldUpdate": "Allow this role to update the field {{field}}",
-        "disallowFieldAccessibility": "Disallow this role to see the field {{field}}",
-        "disallowFieldUpdate": "Disallow this role to update the field {{field}}",
-        "grantAddRecordsPermission": "Grant permission to add new records",
-        "grantDeleteRecordsPermission": "Grant permission to delete records",
-        "grantFilterDeleteRecordsPermission": "Grant permission to delete records that satisfies filter",
-        "grantFilterReadRecordsPermission": "Grant permission to see records that satisfies filter",
-        "grantFilterUpdateRecordsPermission": "Grant permission to update records that satisfies filter",
-        "grantReadRecordsPermission": "Grant permission to see records",
-        "grantUpdateRecordsPermission": "Grant permission to update records",
-        "hideFeature": "Hide {{page}} from this role",
-        "limitedDeleteRecordsPermission": "Provide limited permission to delete records, based on filters",
-        "limitedReadRecordsPermission": "Provide limited permission to see records, based on filters",
-        "limitedUpdateRecordsPermission": "Provide limited permission to update records, based on filters",
-        "notGrantAddRecordsPermission": "Does not grant permission to add new records",
-        "notGrantDeleteRecordsPermission": "Does not grant permission to delete records",
-        "notGrantFilterDeleteRecordsPermission": "Does not grant permission to delete records that satisfies filter",
-        "notGrantFilterReadRecordsPermission": "Does not grant permission to see records that satisfies filter",
-        "notGrantFilterUpdateRecordsPermission": "Does not grant permission to update records that satisfies filter",
-        "notGrantReadRecordsPermission": "Does not grant permission to see records",
-        "notGrantUpdateRecordsPermission": "Does not grant permission to update records",
-        "showFeature": "Show {{page}} to this role"
-      },
-      "update": {
-        "permissions": "Permissions",
-        "title": "Update role permissions and channels"
-      }
-    },
-    "share": {
-      "modal": {
-        "copy": "Copy to clipboard",
-        "title": "Share dashboard url"
-      }
-    },
-    "templates": {
-      "available": "Available email templates",
-      "delete": {
-        "confirmationMessage": "Are you sure you want to delete the template '{{name}}'?"
-      },
-      "edit": {
-        "body": "Body",
-        "name": "Template name",
-        "new": "New notification template",
-        "subject": "Subject",
-        "update": "Edit notification template"
-      },
-      "errors": {
-        "empty": "Please select one or more templates"
-      },
-      "select": {
-        "email": "Select an email template"
-      },
-      "type": {
-        "email": "Email",
-        "title": "Template type"
-      }
-    },
-    "user": {
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the user {{name}}?",
-        "title": "Delete user"
-      },
-      "invite": {
-        "confirm": "Invite",
-        "role": {
-          "additionalAttributes": "Set additional attributes",
-          "description": "Select the role to assign"
-        }
-      },
-      "summary": {
-        "country": "Country",
-        "firstName": "First name",
-        "lastName": "Last name",
-        "locationType": "Location type",
-        "region": "Region",
-        "roles": {
-          "application": "Application roles",
-          "backoffice": "Back-Office roles",
-          "selectedApplication": "Selected application",
-          "selectedGroups": "Selected groups",
-          "selectedRoles": "Selected roles"
-        },
-        "title": "Summary"
-      },
-      "update": {
-        "title": "Update user"
-      }
-    },
-    "users": {
-      "invite": {
-        "add": "Add new user",
-        "confirm": "Invite users",
-        "description": "Select existing users, invite new users or import from Excel file"
-      },
-      "onDelete": {
-        "plural": "Users were correctly deleted.",
-        "singular": "User was correctly deleted."
-      },
-      "onInvite": {
-        "plural": "Users were invited.",
-        "singular": "User was invited."
-      },
-      "onNotDelete": {
-        "plural": "Users were not deleted. {{error}}",
-        "singular": "User was deleted. {{error}}"
-      },
-      "onNotInvite": {
-        "plural": "Users were not invited. {{error}}",
-        "singular": "User was not invited. {{error}}"
-      },
-      "paginator": {
-        "ariaLabel": "Select page of users"
-      }
-    },
-    "widget": {
-      "chart": {
-        "errors": {
-          "aggregation": {
-            "invalid": "Invalid aggregation"
-          }
-        },
-        "filters": {
-          "select": "Select a filter..."
-        },
-        "other": "Other"
-      },
-      "display": {
-        "tooltip": {
-          "placeholder": "Enter a value for tooltip"
-        }
-      },
-      "expand": "Expand",
-      "grid": {
-        "actions": {
-          "detail": "Open detail",
-          "downloadReport": "Download",
-          "goTo": "Go to page",
-          "history": "Show history"
-        },
-        "errors": {
-          "autoSaveFailed": "Action stopped due to some invalid records. Please review them before taking any other action.",
-          "invalid": {
-            "backoffice": "Invalid grid configuration",
-            "frontoffice": "Invalid grid configuration, please contact your admin",
-            "widgets": "Invalid grid configuration, please contact your admin"
-          },
-          "metaQueryBuildFailed": "Error building metadata",
-          "metaQueryFetchFailed": "Error fetching metadata: {{error}}",
-          "missingDataset": "Select a dataset in settings",
-          "noRowsSelected": "No rows selected",
-          "queryBuildFailed": "Error building query",
-          "queryFetchFailed": "Error fetching data: {{error}}",
-          "validationFailed": "The following records could not be saved due to validation rules:\n{{errors}}\nPlease edit the record using the 'update' button for more details."
-        },
-        "export": {
-          "columns": {
-            "choice": {
-              "all": "All available columns",
-              "visible": "Only visible columns"
-            },
-            "title": "Select columns to export"
-          },
-          "dataset": {
-            "choice": {
-              "all": "All records in view",
-              "selected": "Only selected records"
-            },
-            "title": "Select records to export"
-          },
-          "email": {
-            "title": "Send me the file by email",
-            "tooltip": "If checked, instead of waiting for the export to be fully built before downloading it, you will receive an email with the export attached once it's ready."
-          },
-          "format": {
-            "title": "Select export format"
-          }
-        },
-        "filter": {
-          "toggle": "Toggle visibility of filter"
-        },
-        "item": {
-          "few": "{{count}} items",
-          "none": "No item",
-          "one": "{{count}} item"
-        },
-        "layout": {
-          "button": {
-            "title": "This will erase current layout with default layout"
-          },
-          "reset": "Reset default Layout"
-        },
-        "loading": {
-          "records": "Loading records...",
-          "settings": "Loading settings..."
-        },
-        "map": {
-          "mapDetailsTitle": "Query Map View",
-          "mapDetailsTooltip": "Centered by default on selected record"
-        },
-        "openSettings": "Open settings",
-        "tooltip": {
-          "displayMap": "Display map",
-          "openPage": "Navigate to page",
-          "saved": "Changes saved",
-          "unsaved": "Click on save button to upload changes",
-          "uploadFailed": "Record not saved. Click to see more details"
-        },
-        "validation": {
-          "help": "Please edit the record using the 'update' button for more details.",
-          "questionTitle": "Errors on field {{question}}:",
-          "subtitle": "These errors where found while saving changes:",
-          "title": "Validation failed for record {{record}}"
-        }
-      },
-      "settings": {
-        "chart": {
-          "auto": "auto",
-          "axes": "Axes",
-          "categories": "Categories",
-          "color": "Color",
-          "filters": {
-            "add": "Add filter",
-            "delete": "Delete filter",
-            "empty": "No filters configured",
-            "title": "Predefined filters"
-          },
-          "grid": {
-            "buttons": {
-              "modifySelectedRows": {
-                "confirmation": "Are you sure you want to modify the selected rows?"
-              }
-            },
-            "title": "Gridlines",
-            "x": {
-              "display": "Display horizontal gridlines"
-            },
-            "y": {
-              "display": "Display vertical gridlines"
-            }
-          },
-          "hideLegend": "Hide legend",
-          "labels": {
-            "percentage": "Percentage",
-            "showCategory": "Show category labels",
-            "showValue": "Show value labels",
-            "title": "Labels",
-            "valueType": "Value type"
-          },
-          "legend": "Legend",
-          "orientation": "Orientation",
-          "other": "Other",
-          "palette": {
-            "enable": "Use Custom Palette",
-            "title": "Color palette"
-          },
-          "position": "Position",
-          "series": {
-            "fill": "Fill",
-            "interpolation": {
-              "step": "Step interpolation",
-              "title": "Interpolation"
-            },
-            "showSeries": "Show series",
-            "stack": {
-              "enable": "Plot series",
-              "usePercentage": "Use percentage"
-            },
-            "title": "Series"
-          },
-          "size": "Size",
-          "stepSize": "Step size",
-          "style": "Style",
-          "text": "Text",
-          "title": {
-            "color": "Title color",
-            "format": "Title format"
-          },
-          "tooltip": {
-            "palette": "Palette provides default colors to chart elements if not manually set.",
-            "stepSize": "Interval between each tick mark on the chart's axis, when possible"
-          },
-          "type": "Chart Type",
-          "xAxis": "X Axis",
-          "yAxis": "Y Axis"
-        },
-        "close": {
-          "confirmationMessage": "Some changes will be lost when closing edition. Do you want to continue?"
-        },
-        "editor": {
-          "recordSelection": "Record selection",
-          "title": "Editor"
-        },
-        "grid": {
-          "actions": {
-            "add": "Add new records",
-            "convert": "Convert records",
-            "delete": "Delete records",
-            "export": "Export records",
-            "goTo": {
-              "column": {
-                "label": "Column name",
-                "placeholder": "Type a title for the column..."
-              },
-              "field": {
-                "label": "Pass field as query parameter",
-                "placeholder": "Select a field"
-              },
-              "label": "Navigate to page",
-              "target": {
-                "label": "Target page",
-                "placeholder": "Select a page"
-              }
-            },
-            "inline": "Inline edition",
-            "navigateToPage": "Navigate to page",
-            "pageUrl": {
-              "label": "Target page",
-              "placeholder": "Select a page"
-            },
-            "pageUrlTitle": {
-              "label": "Column name",
-              "placeholder": "Type a title for the column..."
-            },
-            "remove": "Remove",
-            "show": "Show history",
-            "showDetails": "Show record details",
-            "title": "Enabled actions",
-            "update": "Update records",
-            "useRecordId": "Pass id as query parameter"
-          },
-          "aggregations": {
-            "add": {
-              "choice": {
-                "create": "Create a new aggregation"
-              }
-            },
-            "title": "Grid aggregations"
-          },
-          "buttons": {
-            "callback": {
-              "attach": "Attach to record",
-              "displayField": "Display field",
-              "export": "Export selected dataset",
-              "modify": "Auto-modify selected rows",
-              "modifyField": "Field to update",
-              "modifyValue": "Value to attribute",
-              "notify": {
-                "message": "Notification message"
-              },
-              "prefill": "Pre-fill form with selected data",
-              "save": "Auto-save",
-              "selectAllRecords": "Select all records",
-              "selectAllRecordsActivePage": "Select all records on the active page",
-              "selectDisplay": "Select displayed fields",
-              "sendMail": "Send mail",
-              "workflow": {
-                "close": "Close workflow",
-                "confirm": "Confirmation message",
-                "next": "Go to next step",
-                "previous": "Go to previous step"
-              }
-            },
-            "create": "Add a button",
-            "defaultName": "Action button",
-            "enable": "Enable",
-            "placeholder": {
-              "modifyValue": "Set as null"
-            },
-            "requireConfirmation": "Require confirmation",
-            "title": "Quick action buttons",
-            "tooltip": {
-              "attach": "When enabled, you must provide a form and a field of this form. All selected rows will be attached to a record from this form. The user will be able to choose which record using a the given field",
-              "mail": {
-                "selectDistributionList": "Select the distribution list that will set recipients of the email",
-                "selectTemplates": "Select the email templates users will be allowed to choose from when using the action"
-              },
-              "notify": "When enabled, you must provide a channel and a message. All selected rows will be sent as a single notification on the specified channel. The provided message is used to define the notification’s action",
-              "publish": "When enabled, you must provide a channel. All selected rows will be sent as a single publication on the specified channel. Everyone listening to this channel can receive the records"
-            }
-          },
-          "display": {
-            "actionsTitle": "Display actions title",
-            "injectClasses": {
-              "title": "Inject values as CSS classes",
-              "tooltip": "When a field is selected, it's value will be added to to <tr> element as a class, allowing it to be targeted by custom styling"
-            },
-            "showSingleActionAsButton": "Show single action as button"
-          },
-          "hint": {
-            "actions": {
-              "add": "If authorized, user can add new records using selected template",
-              "convert": "If authorized, user can convert record using another template of selected resource",
-              "delete": "If authorized, user can delete visible records",
-              "export": "User can export selected columns of visible records",
-              "goTo": "User can go to specified page on click",
-              "inline": "If authorized, user can edit records in the grid",
-              "navigateToPage": "User can go to specified page on click",
-              "show": "User can see full history of visible records",
-              "showDetails": "User can see full details of visible records",
-              "update": "If authorized, user can update visible records"
-            },
-            "attachToRecord": "If the selected records are not attached to any records, the action will be canceled",
-            "buttons": "Quick action buttons will appear on the widget and allow you to complete any of the actions below",
-            "executionOrder": "Selected actions will be executed in the displayed order",
-            "prefillForm": "If no record is created at this point, the action will be canceled"
-          },
-          "layouts": {
-            "add": {
-              "choice": {
-                "create": "Create a new layout",
-                "load": "Load existing layout"
-              },
-              "title": "Add new layout"
-            },
-            "edit": {
-              "title": "Layout configuration"
-            },
-            "select": "Select a layout",
-            "title": "Grid layouts"
-          },
-          "tooltip": {
-            "template": "Select a template for addition and edition of records",
-            "useRecordId": "Url will contain id of the item, in order to redirect to contextual page, if configured"
-          },
-          "warnings": {
-            "add": "Please select a template",
-            "general": "Warning: actions contain errors"
-          }
-        },
-        "iconPicker": {
-          "default": "Default",
-          "placeholder": "Click to select an icon"
-        },
-        "map": {
-          "basemap": "Base map",
-          "category": "Map quick layers",
-          "dataset": "Data set selection",
-          "edit": {
-            "aggregation": "Aggregation",
-            "cluster": {
-              "autoSizeCluster": "Cluster auto-sizing",
-              "cluster": "Cluster",
-              "clusterSettings": "Cluster settings",
-              "clustering": "Clustering",
-              "fields": "Cluster fields",
-              "font": "Font",
-              "fontSize": "Font size",
-              "high": "High",
-              "label": "Cluster label",
-              "lightMode": "Light mode",
-              "low": "Low",
-              "max": "Max",
-              "min": "Min",
-              "overrideSymbol": "Override cluster symbol",
-              "popups": "Cluster pop-ups",
-              "radius": "Cluster radius",
-              "sizeRange": "Size range",
-              "symbol": "Symbol style"
-            },
-            "datasource": {
-              "origin": "Origin"
-            },
-            "fields": "Fields",
-            "filter": "Filter",
-            "groupLayers": "Group layers",
-            "labels": "Labels",
-            "layerDatasource": "Layer datasource",
-            "layerEdition": "Layer edition",
-            "layerProperties": "Layer properties",
-            "layerStyling": "Layer styling",
-            "popup": "Pop-up",
-            "properties": {
-              "defaultVisibility": "Visible by default",
-              "from": "from zoom ",
-              "opacity": "Opacity",
-              "to": " to zoom",
-              "visibilityRange": "Visibility range",
-              "zoom": "Current zoom"
-            },
-            "reduction": {
-              "noReduction": "No reduction",
-              "reduction": "Reduction"
-            },
-            "style": {
-              "color": "Color",
-              "fieldForSize": "Size based on field",
-              "icon": "Icon",
-              "size": "Size",
-              "stylingType": "{{layerType}} styling"
-            },
-            "styling": {
-              "heatmapOptions": {
-                "blur": "Blur",
-                "gradient": "Gradient",
-                "minOpacity": "Minimum opacity",
-                "radius": "Radius"
-              }
-            }
-          },
-          "errors": {
-            "latitude": "Invalid latitude, please select a number between -90 and 90",
-            "longitude": "Invalid longitude, please select a number between -180 and 180"
-          },
-          "geospatial": {
-            "layersStyles": {
-              "fill": {
-                "color": "Fill color",
-                "opacity": "Fill opacity",
-                "title": "Fill"
-              },
-              "marker": {
-                "color": "Marker color",
-                "opacity": "Marker opacity",
-                "title": "Marker"
-              },
-              "outline": {
-                "color": "Outline color",
-                "opacity": "Outline opacity",
-                "title": "Outline",
-                "width": "Outline width"
-              },
-              "title": "Layer styles"
-            }
-          },
-          "layers": {
-            "add": "Add new layer",
-            "chooseLayer": "Choose a layer",
-            "createGroup": "Create a new group layer",
-            "createLayer": "Create a new layer",
-            "dataSource": {
-              "fieldMapping": "Field Mapping",
-              "geoField": "GeoField",
-              "latitude": "Latitude",
-              "longitude": "Longitude"
-            },
-            "edit": "Update layer {{name}}",
-            "online": {
-              "info": "Search for online layers in arcGIS online",
-              "select": "Search layers",
-              "selected": "Selected layers",
-              "title": "Online layers"
-            },
-            "point": {
-              "addNew": "Add new marker rule",
-              "category": "Map quick layers",
-              "color": "Color",
-              "info": "Display markers in the map for each entry of your data, binding dataset number fields to geolocation",
-              "rules": "Marker rules",
-              "rulesInfo": "Customize the size and colors of your markers",
-              "size": "Size",
-              "title": "Marker layers"
-            },
-            "popup": {
-              "addField": "Add field",
-              "description": "Description",
-              "fields": "Fields",
-              "fieldsElements": {
-                "description": "Description",
-                "title": "Title"
-              },
-              "popup": "Popup",
-              "popupElements": "Popup elements",
-              "text": "Text",
-              "title": "Title",
-              "tooltip": {
-                "text": "Type '{' to start using fields from the datasource"
-              }
-            },
-            "remove": "Remove layer",
-            "selectLayer": "Select existing layer",
-            "styling": {
-              "style": "Style"
-            },
-            "types": {
-              "cluster": "cluster",
-              "heatmap": "heatmap",
-              "point": "point",
-              "polygon": "polygon"
-            }
-          },
-          "legend": {
-            "high": "High",
-            "low": "Low",
-            "title": "Legend"
-          },
-          "popup": {
-            "label": "Fields displayed in the popup",
-            "location": "Location",
-            "of": "{{current}} of {{total}}",
-            "zoomTo": "Zoom to"
-          },
-          "properties": {
-            "basemap": "Base map",
-            "controls": {
-              "download": "Download",
-              "lastUpdate": "Last updated on",
-              "lastUpdateError": "Last modified time could not be loaded",
-              "lastUpdatePosition": "Select a position to display the control",
-              "layer": "Layers",
-              "legend": "Legend",
-              "measure": "Measure",
-              "search": "Search",
-              "timedimension": "Time dimension",
-              "title": "Visible Map Controls"
-            },
-            "geographicExtent": "Geographic extent",
-            "geographicExtentValue": "Geographic extent value",
-            "latitude": "Map center latitude",
-            "longitude": "Map center longitude",
-            "setByMap": "Set By Map",
-            "title": "Map Parameters",
-            "webmap": "WebMap",
-            "zoom": "Default zoom"
-          },
-          "renderer": {
-            "default": "Default",
-            "defaultLabel": "Default label",
-            "label": "Label",
-            "symbol": "Symbol",
-            "uniqueValue": "Unique values",
-            "value": "Value"
-          },
-          "tooltip": {
-            "category": "Selecting a field will separate your records into different layers, accessible on top right corner of the map",
-            "cluster": {
-              "autoSize": "If enabled, size of clusters is automated. Else, you can select one.",
-              "lightMode": "If enabled, label uses white. Else, it displays in black."
-            },
-            "dataset": "Select data points below and drag them to 'selected fields' on the right. They will be displayed in the pop-up when clicking on a marker",
-            "default": {
-              "latitude": "Set the default latitude of the center of the map. You can use 'Set By Map' to use the latitude of the preview map.",
-              "longitude": "Set the default longitude of the center of the map. You can use 'Set By Map' to use the longitude of the preview map.",
-              "zoom": "Select a default zoom for the map display"
-            },
-            "geographicExtent": "You can input a static value, or use {{context}} or {{filter}} notation to dynamically inject a value"
-          }
-        },
-        "style": {
-          "customStyling": "Custom Styling"
-        },
-        "summaryCard": {
-          "add": "Add new card",
-          "card": {
-            "dataSource": {
-              "layoutStyles": {
-                "queryFilters": {
-                  "help": "Make sure to remove all unused variables, to prevent null arguments to be sent.",
-                  "noVariables": "No variables defined",
-                  "refresh": "See all graphQL variables",
-                  "title": "GraphQL variable mapping",
-                  "tooltip": "Set values for the GraphQL variables defined in the reference data query. You can get values from the filters using the {{filter.<question-name>}} templates. E.g.: { \"region\": {{filter.region}} }"
-                },
-                "title": "Layout styles",
-                "use": "Use layout styles",
-                "wholeRow": {
-                  "option1": "Apply to all fields",
-                  "option2": "Apply to the whole card",
-                  "title": "Whole row styles:"
-                }
-              },
-              "title": "Data source"
-            },
-            "display": {
-              "dataSource": "Show link to data source",
-              "header": "Header",
-              "padding": "Use card inner padding",
-              "title": "Card display",
-              "tooltip": {
-                "datasource": "Add a button in widget's header to view card's data source"
-              }
-            },
-            "gridActions": {
-              "title": "Grid actions",
-              "tooltip": "Enabled grid actions"
-            },
-            "preview": {
-              "title": "Preview"
-            },
-            "textEditor": {
-              "alert": "You can add variables e.g: {{data.variable}} and calculate e.g: {{calc.round( value ; precision )}}",
-              "title": "Text editor"
-            },
-            "title": "Card settings",
-            "valueSelector": {
-              "title": "Value selector"
-            }
-          },
-          "create": {
-            "choice": {
-              "blank": "Start from blank",
-              "template": "Start from template"
-            }
-          },
-          "dynamic": "Dynamic",
-          "exportable": "Allow export of the cards",
-          "gridMode": "Allow to show as grid",
-          "hint": {
-            "dynamic": "Dynamic Summary cards adapt their display to the number of elements in the datasource. You must define a single card which will be repeated for each element."
-          },
-          "loadMore": {
-            "infiniteScroll": "Use infinite scrolling",
-            "pagination": "Use pagination",
-            "title": "Trigger for loading more data"
-          },
-          "options": {
-            "ariaLabel": "Select an option"
-          },
-          "static": "Static"
-        },
-        "tabs": {
-          "addNewTab": "Add a new tab",
-          "deleteTab": "Delete tab"
-        }
-      },
-      "styling": "Edit styling",
-      "summaryCard": {
-        "dataSource": "Data Source",
-        "errors": {
-          "invalidSource": "The data source is invalid: please edit the settings."
-        },
-        "viewAsCards": "View as cards",
-        "viewAsGrid": "View as grid"
-      },
-      "text": {
-        "aggregations": {
-          "alert": "You can build custom aggregations and inject them in the editor using {{aggregation.<id>}} placeholders.",
-          "template": {
-            "add": "Add new template aggregation",
-            "edit": "Edit template aggregation"
-          }
-        }
-      }
-    }
-  },
-  "kendo": {
-    "combobox": {
-      "clearTitle": "Clear value",
-      "noDataText": "No available choice"
-    },
-    "datepicker": {
-      "dateFormat": "YYYY/MM/DD or expression ({{today}} or {{now}})",
-      "dateLabel": "Select a date",
-      "endLabel": "Select a end date",
-      "startLabel": "Select a start date",
-      "today": "Today",
-      "toggle": "Choose a date"
-    },
-    "datetimepicker": {
-      "accept": "Accept",
-      "acceptLabel": "Accept",
-      "cancel": "Cancel",
-      "cancelLabel": "Cancel",
-      "dateTab": "Date",
-      "dateTabLabel": "Date",
-      "now": "Now",
-      "timeTab": "Time",
-      "timeTabLabel": "Time",
-      "today": "Today",
-      "toggle": "Choose a date and a time"
-    },
-    "editor": {
-      "addColumnAfter": "Add column after",
-      "addColumnBefore": "Add column before",
-      "addRowAfter": "Add row after",
-      "addRowBefore": "Add row before",
-      "alignCenter": "Center text",
-      "alignJustify": "Justify",
-      "alignLeft": "Align text left",
-      "alignRight": "Align text right",
-      "backColor": "Background color",
-      "bold": "Bold",
-      "cleanFormatting": "Clean formatting",
-      "createLink": "Insert link",
-      "deleteColumn": "Delete column",
-      "deleteRow": "Delete row",
-      "deleteTable": "Delete table",
-      "dialogApply": "Apply",
-      "dialogCancel": "Cancel",
-      "dialogInsert": "Insert",
-      "dialogUpdate": "Update",
-      "fileText": "Text",
-      "fileTitle": "Title",
-      "fileWebAddress": "Web address",
-      "fontFamily": "Select font family",
-      "fontSize": "Select font size",
-      "foreColor": "Color",
-      "format": "Format",
-      "imageAltText": "Alternate text",
-      "imageHeight": "Height (px)",
-      "imageWebAddress": "Web address",
-      "imageWidth": "Width (px)",
-      "indent": "Indent",
-      "insertFile": "Insert file",
-      "insertImage": "Insert image",
-      "insertOrderedList": "Insert ordered list",
-      "insertTable": "Insert Table",
-      "insertUnorderedList": "Insert unordered list",
-      "italic": "Italic",
-      "linkOpenInNewWindow": "Open link in new window",
-      "linkText": "Text",
-      "linkTitle": "Title",
-      "linkWebAddress": "Web address",
-      "outdent": "Outdent",
-      "print": "Print",
-      "redo": "Redo",
-      "selectAll": "Select All",
-      "strikethrough": "Strikethrough",
-      "subscript": "Subscript",
-      "superscript": "Superscript",
-      "underline": "Underline",
-      "undo": "Undo",
-      "unlink": "Remove Link",
-      "unselectAll": "Unselect all",
-      "viewSource": "View source"
-    },
-    "fileselect": {
-      "dropFilesHere": "Drop files here to select",
-      "select": "Select files..."
-    },
-    "grid": {
-      "columnMenu": "'{columnName} Column Menu'",
-      "columns": "Columns",
-      "columnsApply": "Apply",
-      "columnsReset": "Reset",
-      "detailCollapse": "Collapse Details",
-      "detailExpand": "Expand Details",
-      "filter": "Filter",
-      "filterAfterOperator": "Is after",
-      "filterAfterOrEqualOperator": "Is after or equal to",
-      "filterAndLogic": "And",
-      "filterBeforeOperator": "Is before",
-      "filterBeforeOrEqualOperator": "Is before or equal to",
-      "filterBooleanAll": "(All)",
-      "filterClearButton": "Clear",
-      "filterContainsOperator": "Contains",
-      "filterDateToday": "Today",
-      "filterDateToggle": "Toggle calendar",
-      "filterEndsWithOperator": "Ends with",
-      "filterEqOperator": "Is equal to",
-      "filterFilterButton": "Filter",
-      "filterGtOperator": "Is greater than",
-      "filterGteOperator": "Is greater than or equal to",
-      "filterInputLabel": "'{columnName} Filter'",
-      "filterIsEmptyOperator": "Is empty",
-      "filterIsFalse": "is false",
-      "filterIsInOperator": "Is in",
-      "filterIsNotEmptyOperator": "Is not empty",
-      "filterIsNotInOperator": "Is not in",
-      "filterIsNotNullOperator": "Is not null",
-      "filterIsNullOperator": "Is null",
-      "filterIsTrue": "is true",
-      "filterLtOperator": "Is less than",
-      "filterLteOperator": "Is less than or equal to",
-      "filterMenuLogicDropDownLabel": "'{columnName} Filter Logic'",
-      "filterMenuOperatorsDropDownLabel": "'{columnName} Filter Operators'",
-      "filterMenuTitle": "'{columnName} Filter Menu'",
-      "filterNotContainsOperator": "Does not contain",
-      "filterNotEqOperator": "Is not equal to",
-      "filterNumericDecrement": "Decrease value",
-      "filterNumericIncrement": "Increase value",
-      "filterOrLogic": "Or",
-      "filterStartsWithOperator": "Starts with",
-      "gridLabel": "Data table",
-      "groupCollapse": "Collapse Group",
-      "groupExpand": "Expand Group",
-      "groupPanelEmpty": "Drag a column header and drop it here to group by that column",
-      "loading": "Loading",
-      "lock": "Lock",
-      "noRecords": "No records available.",
-      "pagerFirstPage": "Go to the first page",
-      "pagerItems": "items",
-      "pagerItemsPerPage": "items per page",
-      "pagerLabel": "'Page navigation, page {currentPage} of {totalPages}'",
-      "pagerLastPage": "Go to the last page",
-      "pagerNextPage": "Go to the next page",
-      "pagerOf": "of",
-      "pagerPage": "Page",
-      "pagerPageNumberInputTitle": "Page Number",
-      "pagerPreviousPage": "Go to the previous page",
-      "selectAllCheckboxLabel": "Select All Rows",
-      "selectionCheckboxLabel": "Select Row",
-      "setColumnPosition": "Set Column Position",
-      "sortAscending": "Sort Ascending",
-      "sortDescending": "Sort Descending",
-      "sortable": "Sortable",
-      "sortedAscending": "Sorted ascending",
-      "sortedDefault": "Not sorted",
-      "sortedDescending": "Sorted descending",
-      "stick": "Stick",
-      "unlock": "Unlock",
-      "unstick": "Unstick"
-    },
-    "multiselect": {
-      "clearTitle": "Clear value",
-      "noDataText": "No available choice"
-    },
-    "pager": {
-      "firstPage": "Go to the first page",
-      "items": "items",
-      "itemsPerPage": "items per page",
-      "label": "'Page navigation, page {currentPage} of {totalPages}'",
-      "lastPage": "Go to the last page",
-      "nextPage": "Go to the next page",
-      "of": "of",
-      "page": "Page",
-      "pageNumberInputTitle": "Page Number",
-      "previousPage": "Go to the previous page"
-    },
-    "tilelayout": {
-      "component": {
-        "items": "items",
-        "itemsPerPage": "Items per page",
-        "of": "of",
-        "page": "Page"
-      }
-    },
-    "timepicker": {
-      "accept": "Accept",
-      "acceptLabel": "Accept",
-      "cancel": "Cancel",
-      "cancelLabel": "Cancel",
-      "now": "Now",
-      "toggle": "Choose a time"
-    },
-    "upload": {
-      "dropFilesHere": "Drop files here to upload",
-      "invalidMaxFileSize": "File size too large.",
-      "select": "Select files..."
-    }
-  },
-  "models": {
-    "apiConfiguration": {
-      "authType": "Authentication type",
-      "new": "New API Configuration",
-      "selectAuthType": "Select authentication type"
-    },
-    "application": {
-      "description": "Description",
-      "errors": {
-        "style": {
-          "notFound": "Unable to load application's style"
-        }
-      },
-      "id": "Application ID",
-      "new": "New application",
-      "notifications": {
-        "notPublished": "Application not published.",
-        "published": "{{value}} application published.",
-        "updated": "Application updated."
-      },
-      "setAsFavorite": "Set as favorite",
-      "subscription": {
-        "create": "Create a subscription"
-      }
-    },
-    "channel": {
-      "create": "Create a channel",
-      "edit": "Edit channel",
-      "new": "New channel"
-    },
-    "customNotification": {
-      "lastExecution": "Last execution",
-      "schedule": "Schedule",
-      "type": "Notification type"
-    },
-    "dashboard": {
-      "activateFiltering": "Activate filtering",
-      "buttonActions": {
-        "add": "Add button action",
-        "category": "Button category",
-        "confirmDelete": "Are you sure you want to delete this button action?",
-        "edit": "Edit button action",
-        "href": {
-          "title": "Button href",
-          "tooltip": "The href attribute specifies the destination URL when the button is clicked. Can be a relative or absolute URL."
-        },
-        "one": "Button action",
-        "openInNewTab": "Open in new tab",
-        "text": "Button text",
-        "variant": "Button variant"
-      },
-      "closable": "Closable",
-      "context": {
-        "datasource": {
-          "alert": "Select a datasource, in order to set one page per record of the datasource. You can also set a template, which would be loaded by default if no specific page is created for a record.",
-          "info": "Indicate the field that would be use to select records",
-          "set": "Set context datasource",
-          "title": "Context datasource",
-          "update": "Update context datasource"
-        },
-        "displayField": "Display field",
-        "edition": {
-          "element": "You are editing the view for selected element.",
-          "template": "You are editing template of the page. It will be loaded by default if no specific view is created for a record."
-        },
-        "notifications": {
-          "creatingTemplate": "Creating new template",
-          "loadDefault": "Displaying default template",
-          "templateCreated": "New template created"
-        },
-        "origin": "Context origin",
-        "refData": {
-          "element": "Element"
-        },
-        "selectDisplayField": "Select display field",
-        "selectOrigin": "Select context origin",
-        "title": "Context",
-        "tooltip": {
-          "useContextEditor": "Use context editor",
-          "useDefaultEditor": "Use default editor"
-        }
-      },
-      "contextFilter": "Context filter",
-      "dashboardFilter": "Dashboard filter",
-      "deactivateFiltering": "Deactivate filtering",
-      "filterVariant": {
-        "title": "Filter variant",
-        "variantsOptions": {
-          "selectOrigin": "Select filter variant",
-          "variant_default": "Default",
-          "variant_modern": "Modern"
-        }
-      },
-      "historicalDate": "Get dataset at",
-      "share": "Share Dashboard",
-      "tooltip": {
-        "filter": {
-          "closable": "When variant is modern, or application is used as web element, it will indicate if filter can be closed or not",
-          "fields": "You can use fields from the dashboard filter as well as static values to filter the dataset.",
-          "position": "Only applicable when default variant is active"
-        },
-        "historicalDate": "You can use a field from the dashboard filter to query dataset at a specific date.\nIndicate which field to use, by using this syntax: {{filter.<name>}}."
-      }
-    },
-    "form": {
-      "core": "Core",
-      "create": "Create a Form",
-      "edit": "Edit form",
-      "field": {
-        "itemsLabel": "Items label",
-        "label": "Label",
-        "name": "Field name",
-        "usedIn": "Used in"
-      },
-      "new": "New form",
-      "notifications": {
-        "savingFailed": "Saving failed, some fields require your attention."
-      },
-      "select": "Select a Form",
-      "template": "Template"
-    },
-    "group": {
-      "create": "Create a group",
-      "description": "Description",
-      "fetch": "Fetch groups from service",
-      "title": "Title"
-    },
-    "mapping": {
-      "add": "Add a Mapping",
-      "edit": "Edit a Mapping"
-    },
-    "page": {
-      "add": "Add a Page",
-      "tooltip": {
-        "drag": "Drag and drop to reorder",
-        "duplicate": "Select the application you want to put the copy in"
-      }
-    },
-    "positionAttribute": {
-      "edit": "Edit position attribute",
-      "new": "New position attribute"
-    },
-    "pullJob": {
-      "edit": "Edit pull job",
-      "new": "New pull job",
-      "nextIteration": "Next iteration",
-      "path": "Path",
-      "schedule": "Schedule",
-      "url": "Url"
-    },
-    "record": {
-      "convert": "Convert",
-      "edit": "Edit record",
-      "new": "New record",
-      "notifications": {
-        "conversionIncomplete": "Selected record(s) do not match with some fields from this form.",
-        "rowsAdded": "Added {{length}} row(s) to the field {{field}} in the record {{value}}.",
-        "rowsNotAdded": "Error on add row(s).",
-        "uploadSuccessful": "Records upload successful."
-      },
-      "restore": "Restore",
-      "select": "Select a record"
-    },
-    "referenceData": {
-      "add": "Add new reference data",
-      "select": "Select a reference data"
-    },
-    "resource": {
-      "create": "Create a Resource",
-      "select": "Select a Resource"
-    },
-    "role": {
-      "create": "Create a role",
-      "description": "Description",
-      "title": "Title"
-    },
-    "step": {
-      "new": "New step"
-    },
-    "subscription": {
-      "edit": "Edit subscription",
-      "new": "New subscription"
-    },
-    "user": {
-      "firstName": "First name",
-      "lastName": "Last name",
-      "notifications": {
-        "rolesUpdated": "{{username}} roles updated.",
-        "userImportFail": "The user import has failed"
-      },
-      "username": "Username"
-    },
-    "widget": {
-      "add": "Add a Widget",
-      "chart": {
-        "defaultTitle": "Chart Widget"
-      },
-      "delete": {
-        "confirmationMessage": "Do you confirm the deletion of the widget?",
-        "title": "Delete Widget"
-      },
-      "display": {
-        "border": "Show widget border",
-        "expand": "Show button to expand widget",
-        "header": "Show widget header",
-        "padding": "Use widget inner padding",
-        "searchable": "Allow search",
-        "sortable": "Allow sorting",
-        "title": "Widget display",
-        "tooltip": "Show tooltip"
-      },
-      "map": {
-        "defaultTitle": "Map Widget",
-        "latitude": "Latitude",
-        "longitude": "Longitude",
-        "zoom": "Zoom"
-      },
-      "sorting": {
-        "add": "Add a field",
-        "delete": "Delete sort field",
-        "empty": "No sort field set",
-        "field": "Field",
-        "label": "Label",
-        "management": "Sort fields",
-        "order": "Order",
-        "select": "Select a sort field...",
-        "title": "Sorting"
-      },
-      "tooltip": {
-        "expandButton": {
-          "expand": "Expand widget",
-          "help": "Only appears in front-office or in preview mode",
-          "restore": "Restore default"
-        },
-        "selector": {
-          "collapse": "Hide widget selector",
-          "expand": "Show widget selector"
-        }
-      }
-    },
-    "workflow": {
-      "notifications": {
-        "cannotGoToNextStep": "Cannot go to the next step.",
-        "cannotGoToPreviousStep": "Cannot go to the previous step.",
-        "goToStep": "Back to {{step}} step."
-      }
-    }
-  },
-  "pages": {
-    "administration": {
-      "title": "Administration"
-    },
-    "aggregation": {
-      "preview": {
-        "label": "Aggregation data preview",
-        "missingAggregation": "Cannot load selected aggregation. Aggregation not found"
-      }
-    },
-    "apiConfiguration": {
-      "authentication": "Authentication settings",
-      "baseUrl": "Main endpoint",
-      "clientId": "Client ID",
-      "graphQL": {
-        "endpoint": "GraphQL endpoint",
-        "title": "GraphQL Settings"
-      },
-      "host": "Host settings",
-      "notifications": {
-        "authTokenFetched": "Authentication token fetched, ping again to get the actual response.",
-        "pingFailed": "Ping request failed.",
-        "pingReceived": "Received positive response from ping request."
-      },
-      "ping": "Try settings",
-      "pingUrl": "Ping extension",
-      "placeholder": {
-        "baseUrl": "Base URL for the API",
-        "clientId": "Enter client ID",
-        "graphQLEndpoint": "GraphQL extension",
-        "pingUrl": "Enter ping extension URL",
-        "scope": "Enter scope",
-        "secret": "Enter client secret",
-        "token": "Enter token for authentication",
-        "tokenUrl": "Enter access token URL"
-      },
-      "scope": "Scope",
-      "secret": "Client Secret",
-      "token": "Token",
-      "tokenUrl": "Access token URL"
-    },
-    "apiConfigurations": {
-      "create": "Create an API Configuration"
-    },
-    "appBuilder": {
-      "title": "Site builder"
-    },
-    "application": {
-      "addPage": {
-        "form": {
-          "title": "Available forms"
-        },
-        "selectType": "Select which type of page you want to create",
-        "startFromWidget": "Start from a widget"
-      },
-      "empty": {
-        "add": "Add a Page",
-        "create": "Click on create to finish the process",
-        "customize": "Customize each of the pages created"
-      },
-      "positionAttributes": {
-        "create": "Create a position category",
-        "title": "Attributes"
-      },
-      "settings": {
-        "actions": "Actions"
-      }
-    },
-    "applications": {
-      "all": "All applications",
-      "goTo": "Go to Application list",
-      "recent": "Recent applications",
-      "title": "My applications"
-    },
-    "dashboard": {
-      "update": {
-        "exit": "Exit without saving changes",
-        "exitMessage": "There are unsaved changes on the page. Are you sure you want to exit?"
-      }
-    },
-    "formBuilder": {
-      "errors": {
-        "choices": {
-          "valueDuplicated": "Please provide unique values for each of the choices of question: {{question}}"
-        },
-        "dataFieldDuplicated": "Data name duplicated : {{name}}. Please provide different value names for all questions.",
-        "missingName": "Missing value name for an element on page {{page}}. Please provide a valid data value name (snake_case) to save the form.",
-        "multipletext": {
-          "missingName": "Please provide name or title for each text of question: {{question}}"
-        },
-        "selectApplication": "Missing value application for an element on page {{page}}. Please select at least one application in properties of {{question}} to save the form.",
-        "snakecase": "The value name {{name}} on page {{page}} is invalid. Please conform to snake_case."
-      },
-      "move": {
-        "down": "Move down",
-        "up": "Move up"
-      },
-      "questionsCategories": {
-        "core": "Question Library"
-      },
-      "title": "Advanced settings"
-    },
-    "forms": {
-      "title": "Available forms"
-    },
-    "profile": {
-      "notifications": {
-        "notUpdated": "Error on saving preferences.",
-        "updated": "Preferences saved."
-      },
-      "title": "Your profile",
-      "password": {
-        "change": "Change password"
-      }
-    },
-    "pullJobs": {
-      "create": "Create a pull job"
-    },
-    "referenceData": {
-      "csv": "CSV input",
-      "fields": {
-        "fetch": "Fetch fields",
-        "help": "The fields are calculated based on the attributes of the first item in the payload.",
-        "missingConfig": "Can't fetch fields. Missing configuration: {{config}}",
-        "noFields": "No fields found",
-        "title": "Field"
-      },
-      "graphQLFilter": "GraphQL query parameters",
-      "pagination": {
-        "cursorPath": "Cursor path",
-        "cursorVariable": "Cursor query variable",
-        "offsetVariable": "Offset query variable",
-        "pageSizeVariable": "Page size query variable",
-        "pageVariable": "Page number query variable",
-        "strategy": "Pagination strategy",
-        "totalCountPath": "Total items count path",
-        "usePagination": {
-          "hint": "Depends on API support, allows fetching data by page",
-          "text": "Use pagination"
-        }
-      },
-      "path": {
-        "placeholder": "Enter a valid JSONPath",
-        "title": "Data path"
-      },
-      "payload": {
-        "label": "Payload",
-        "show": "Show payload"
-      },
-      "placeholder": {
-        "csv": "Insert CSV here",
-        "graphQLFilter": "Enter a filter to be used once choices are already cached"
-      },
-      "queryName": "Query Name",
-      "tooltip": {
-        "graphQLFilter": "You can use {{lastUpdate}} to dynamically get the last fetch date in SQL format.",
-        "path": "Uses JSONPath syntax to extract items from the JSON response. Examples: $.data[*].name, $.data..countries, $.data.countries.*"
-      },
-      "type": "Type",
-      "validateCsv": "Validate CSV",
-      "valueField": "Value Field"
-    },
-    "workflow": {
-      "addStep": {
-        "selectType": "Select which type of step you want to create"
-      },
-      "deleteStep": {
-        "confirmationMessage": "Are you sure you want to delete {{step}}?\n This action cannot be undone."
-      },
-      "empty": {
-        "add": "Add steps",
-        "customize": "Customize each of the steps created"
-      }
-    }
-  }
+	"common": {
+		"access": "Access",
+		"accessDenied": "Access denied",
+		"account": "Account",
+		"actions": "Actions",
+		"add": "Add",
+		"adminField": "Admin field",
+		"aggregation": {
+			"add": "Add aggregation",
+			"few": "Aggregations",
+			"none": "No aggregation",
+			"one": "Aggregation"
+		},
+		"apiConfiguration": {
+			"few": "API Configurations",
+			"none": "No API Configuration",
+			"one": "API Configuration"
+		},
+		"application": {
+			"few": "Applications",
+			"none": "No application",
+			"one": "Application"
+		},
+		"archive": {
+			"delete": "Delete",
+			"few": "Archive",
+			"modal": {
+				"delete": {
+					"action": "Delete",
+					"confirmationMessage": "Do you want to delete archived page: {{name}}?",
+					"title": "Delete?"
+				},
+				"restore": {
+					"action": "Restore",
+					"confirmationMessage": "Do you want to restore the archived page: {{name}}?",
+					"title": "Restore?"
+				}
+			},
+			"none": "No archived items",
+			"restore": "Restore"
+		},
+		"ariaLabel": {
+			"search": {
+				"clear": "Clear search"
+			}
+		},
+		"asc": "Ascending",
+		"attribute": {
+			"few": "Attributes",
+			"none": "No attribute",
+			"one": "Attribute"
+		},
+		"auto": "Auto",
+		"back": "Back",
+		"bookmarks": "Bookmarks",
+		"calculatedField": {
+			"few": "Calculated Fields",
+			"none": "No Calculated field",
+			"one": "calculated Field"
+		},
+		"cancel": "Cancel",
+		"channel": {
+			"few": "Channels",
+			"none": "No channel",
+			"one": "Channel"
+		},
+		"child": {
+			"edit": "Edit child",
+			"one": "Child"
+		},
+		"clear": "Clear",
+		"close": "Close",
+		"column": {
+			"few": "Columns",
+			"none": "No column",
+			"one": "Column"
+		},
+		"comma": "comma",
+		"copy": "Copy",
+		"create": "Create",
+		"createdOn": "Created on",
+		"cronEditor": {
+			"advanced": "Advanced",
+			"atTime": "At",
+			"daily": "Daily",
+			"day": "Day",
+			"days": "Day(s)",
+			"every": {
+				"feminine": "Every",
+				"masculine": "Every"
+			},
+			"firstWeekDay": "First week day",
+			"hourly": "Hourly",
+			"hours": "Hour(s)",
+			"lastDay": "Last day",
+			"lastWeekDay": "Last week day",
+			"minutely": "Minutely",
+			"minutes": "Minute(s)",
+			"month": "Month",
+			"monthly": "Monthly",
+			"months": {
+				"april": "April",
+				"august": "August",
+				"december": "December",
+				"february": "February",
+				"january": "January",
+				"july": "July",
+				"june": "June",
+				"march": "March",
+				"may": "May",
+				"november": "November",
+				"october": "October",
+				"september": "September"
+			},
+			"of": "of",
+			"ofEvery": "of every",
+			"onThe": {
+				"feminine": "On the",
+				"masculine": "On the"
+			},
+			"seconds": "Second(s)",
+			"week": "Week",
+			"weekDay": "Week Day (MON-FRI)",
+			"weekDays": {
+				"friday": "Friday",
+				"monday": "Monday",
+				"saturday": "Saturday",
+				"sunday": "Sunday",
+				"thursday": "Thursday",
+				"tuesday": "Tuesday",
+				"wednesday": "Wednesday"
+			},
+			"weekNumber": {
+				"fifth": "Fifth",
+				"first": "First",
+				"fourth": "Fourth",
+				"last": "Last",
+				"second": "Second",
+				"third": "Third"
+			},
+			"weekly": "Weekly",
+			"yearly": "Yearly"
+		},
+		"customNotification": {
+			"few": "Custom notifications",
+			"none": "No Custom notification",
+			"one": "Custom notification"
+		},
+		"dashboard": {
+			"few": "Dashboards",
+			"none": "No dashboard",
+			"one": "Dashboard"
+		},
+		"delete": "Delete",
+		"deleteObject": "Delete {{name}}",
+		"deleted": "Deleted",
+		"desc": "Descending",
+		"dismiss": "Dismiss",
+		"display": "Display",
+		"distributionList": {
+			"few": "Distribution lists",
+			"none": "No distribution list",
+			"one": "Distribution list"
+		},
+		"downloadObject": "Download {{name}}",
+		"downloadTemplate": "Get template",
+		"duplicate": "Duplicate",
+		"edit": "Edit",
+		"email": {
+			"few": "Emails",
+			"none": "No email",
+			"one": "Email"
+		},
+		"errors": {
+			"few": "Errors",
+			"objectDuplicated": "{{type}} {{value}} already exists."
+		},
+		"exitFullscreen": "Exit Fullscreen",
+		"export": "Export",
+		"exportObject": "Export {{name}}",
+		"false": "False",
+		"field": {
+			"few": "Fields",
+			"none": "No field",
+			"one": "Field"
+		},
+		"filter": {
+			"apply": "Apply",
+			"clear": "Clear Filter",
+			"empty": "No result",
+			"few": "Filters",
+			"hide": "Hide Filter",
+			"none": "No filter",
+			"one": "Filter",
+			"show": "Show Filter"
+		},
+		"form": {
+			"few": "Forms",
+			"none": "No form",
+			"one": "Form"
+		},
+		"general": "General",
+		"group": {
+			"few": "Groups",
+			"none": "No groups",
+			"one": "Group"
+		},
+		"hide": "Hide",
+		"history": "History",
+		"id": "Id",
+		"input": {
+			"dateRange": "Date range",
+			"none": "-- None --",
+			"rawJson": "Raw JSON"
+		},
+		"label": "Label",
+		"layers": {
+			"few": "Layers",
+			"none": "No layer"
+		},
+		"layout": {
+			"few": "Layouts",
+			"none": "No layout",
+			"one": "Layout"
+		},
+		"loading": "Loading",
+		"modifiedOn": "Modified On",
+		"name": "Name",
+		"next": "Next",
+		"noOptions": "No available choices",
+		"notifications": {
+			"accessDenied": "You don't have permission to see the {{type}}.",
+			"accessNotProvided": "No access provided to this {{type}}. {{error}}",
+			"alreadyExists": "The {{type}} {{value}} already exists on this application.",
+			"copiedToClipboard": "Dashboard link copied!",
+			"dataNotRecovered": "Failure on data recovery",
+			"dataRecovered": "The data has been recovered",
+			"email": {
+				"error": "Something went wrong during the email sending",
+				"errors": {
+					"noDistributionList": "Something went wrong during the email sending: no distribution list found",
+					"noTemplate": "Something went wrong during the email sending: no template found"
+				},
+				"processing": "Sending email...",
+				"ready": "Email ready",
+				"sent": "Email sent"
+			},
+			"fetchingGroups": "Fetching groups from service...",
+			"file": {
+				"download": {
+					"error": "Something went wrong during the download",
+					"ongoing": "Your file export is ongoing. You will receive an email once ready.",
+					"processing": "Downloading file...",
+					"ready": "Your file is ready"
+				},
+				"upload": {
+					"error": "Something went wrong during the upload",
+					"maxFileSize": "Maximum file size is {{size}} MB.",
+					"processing": "Uploading file...",
+					"ready": "File uploaded"
+				}
+			},
+			"formStatus": "The current status of the form does not allow it to be displayed.",
+			"formatInvalid": "Please upload a valid .{{format}} file.",
+			"groups": {
+				"error": "Something went wrong trying to get groups from service",
+				"processing": "Fetching groups from service...",
+				"ready": "Groups fetched"
+			},
+			"history": {
+				"error": "Something went wrong during the history generation. {{error}}"
+			},
+			"loadedFromCache": "{{type}} loaded from cache.",
+			"noOpened": "No opened {{value}}.",
+			"objectCreated": "{{value}} {{type}} was successfully created.",
+			"objectDeleted": "{{value}} was successfully deleted.",
+			"objectDuplicated": "{{type}} {{value}} was successfully duplicated.",
+			"objectInvited": "{{name}} invited.",
+			"objectLocked": "{{name}} edition is locked by another user.",
+			"objectNotCreated": "The {{type}} was not created. {{error}}",
+			"objectNotDeleted": "{{value}} deletion failed. {{error}}",
+			"objectNotDuplicated": "The {{type}} was not duplicated. {{error}}",
+			"objectNotFound": "{{name}} not found.",
+			"objectNotInvited": "{{name}} invitation failed.",
+			"objectNotReordered": "{{type}} not reordered. {{error}}",
+			"objectNotRestored": "{{value}} not restored. {{error}}",
+			"objectNotUpdated": "{{type}} not edited. {{error}}",
+			"objectReordered": "{{type}} reordered.",
+			"objectRestored": "{{value}} restored.",
+			"objectUpdated": "{{value}} {{type}} was successfully edited.",
+			"platformAccessNotGranted": "You don't have a valid access to this platform.",
+			"readAll": "Mark all as read",
+			"statusUpdated": "Status updated to {{value}}.",
+			"unlocked": "{{name}} edition has been unlocked by another user."
+		},
+		"openFullScreen": "Open in Full Screen",
+		"options": "Options",
+		"or": "Or",
+		"page": {
+			"few": "Pages",
+			"none": "No page",
+			"one": "Page"
+		},
+		"pagination": {
+			"empty": "No result",
+			"itemsPerPage": "Items per page",
+			"loadMore": "Load more",
+			"of": "of"
+		},
+		"placeholder": {
+			"address": "Enter an address or place e.g. 1 York St",
+			"email": "Enter email",
+			"name": "Enter a name",
+			"search": "Search...",
+			"title": "Enter a title"
+		},
+		"platform": {
+			"backOffice": "Back-Office"
+		},
+		"position": {
+			"bottomleft": "Bottom left",
+			"bottomright": "Bottom right",
+			"topleft": "Top left",
+			"topright": "Top right"
+		},
+		"positionAttribute": {
+			"few": "Position attributes",
+			"none": "No position attribute",
+			"one": "Position attribute"
+		},
+		"positionCategory": {
+			"few": "Position categories",
+			"none": "No position category",
+			"one": "Position category"
+		},
+		"preview": "Preview",
+		"previous": "Previous",
+		"publish": "Publish",
+		"pullJob": {
+			"few": "Pull jobs",
+			"none": "No pull job",
+			"one": "Pull job"
+		},
+		"record": {
+			"few": "Records",
+			"none": "No record",
+			"one": "Record"
+		},
+		"referenceData": {
+			"few": "Reference Data",
+			"none": "No Reference Data",
+			"one": "Reference Data"
+		},
+		"remove": "Remove",
+		"resource": {
+			"few": "Resources",
+			"none": "No resource",
+			"one": "Resource"
+		},
+		"role": {
+			"few": "Roles",
+			"none": "No role",
+			"one": "Role"
+		},
+		"row": {
+			"few": "Rows",
+			"none": "No row",
+			"one": "Row",
+			"update": {
+				"few": {
+					"content": "Do you really want to update {{quantity}} rows?",
+					"title": "Update rows"
+				},
+				"one": {
+					"content": "Do you really want to update this row?",
+					"title": "Update row"
+				}
+			}
+		},
+		"save": "Save",
+		"saveChanges": "Save changes",
+		"search": "Search",
+		"searchObject": "Search {{name}}",
+		"select": "Select",
+		"selectStatus": "Select a status",
+		"semicolon": "semicolon",
+		"send": "Send",
+		"separator": "Separator",
+		"settings": "Settings",
+		"status": "Status",
+		"status_active": "Active",
+		"status_archived": "Archived",
+		"status_pending": "Pending",
+		"step": {
+			"few": "Steps",
+			"none": "No step",
+			"one": "Step"
+		},
+		"subscription": {
+			"few": "Subscriptions",
+			"none": "No subscription",
+			"one": "Subscription"
+		},
+		"tabs": "Tabs",
+		"template": {
+			"few": "Notification templates",
+			"none": "No template",
+			"one": "Notification template"
+		},
+		"title": "Title",
+		"tooltip": {
+			"dragDrop": "Drag and drop to reorder",
+			"editor": {
+				"insert": "Type '{' to inject expressions and variables"
+			}
+		},
+		"true": "True",
+		"type": {
+			"few": "Types",
+			"none": "No type",
+			"one": "Type"
+		},
+		"update": "Update",
+		"updateObject": "Update {{name}}",
+		"uploadObject": "Upload {{name}}",
+		"user": {
+			"few": "Users",
+			"none": "No user",
+			"one": "User"
+		},
+		"value": {
+			"few": "Values",
+			"none": "No value",
+			"one": "Value"
+		},
+		"viewFullscreen": "View Fullscreen",
+		"viewObject": "View {{name}}",
+		"workflow": {
+			"few": "Workflows",
+			"none": "No workflow",
+			"one": "Workflow"
+		}
+	},
+	"components": {
+		"access": {
+			"canDelete": "Can delete",
+			"canSee": "Can see",
+			"canUpdate": "Can update",
+			"description": "Update {{name}} permissions",
+			"title": "Access"
+		},
+		"aggregation": {
+			"add": {
+				"choice": {
+					"create": "Create a new aggregation",
+					"load": "Load existing aggregation"
+				},
+				"select": "Select an aggregation",
+				"title": "Add new aggregation"
+			},
+			"edit": {
+				"title": "Aggregation configuration"
+			}
+		},
+		"aggregationBuilder": {
+			"accumulators": "Accumulators",
+			"addField": "Add field",
+			"addRule": "Add rule",
+			"addStage": "Add stage",
+			"dataset": {
+				"select": "Select the data source"
+			},
+			"fieldName": "Field name",
+			"groupBy": "Group by",
+			"groupingRules": "Grouping rules",
+			"mapping": {
+				"category": "Category",
+				"field": "Value",
+				"series": "Series"
+			},
+			"operator": "Operator",
+			"operators": {
+				"add": "Add",
+				"avg": "Average",
+				"count": "Count",
+				"day": "Day",
+				"first": "First",
+				"last": "Last",
+				"max": "Maximum",
+				"min": "Minimum",
+				"month": "Month",
+				"multiply": "Multiply",
+				"sum": "Sum",
+				"week": "Week",
+				"year": "Year"
+			},
+			"preview": {
+				"hide": "Hide preview",
+				"show": "Show preview"
+			},
+			"sourceFields": "Select fields",
+			"stages": {
+				"addFields": "Add fields",
+				"custom": "Custom",
+				"filter": "Filter",
+				"group": "Group & Accumulator",
+				"sort": "Sort",
+				"unwind": "Unwind"
+			},
+			"tooltip": {
+				"addFields": "Adds new fields to documents.",
+				"custom": "Defines a custom aggregation function or expression in JavaScript.",
+				"filter": "Returns an array with only those elements that match the condition.",
+				"group": "Group records based on field values and construct personalized accumulators",
+				"groupingRules": "Grouping rules are optional.",
+				"selectedFields": "Only unused fields can be removed.",
+				"sort": "Sorts all input documents and returns them to the pipeline in sorted order.\nEstablishing consecutive sorting stages will simultaneously sort all fields.",
+				"unwind": "Deconstructs an array field from the input documents to output a document for each element."
+			}
+		},
+		"apiConfiguration": {
+			"create": {
+				"errors": {
+					"name": "Invalid name: please only use letters, digits and underscores."
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the API Configuration {{name}}?",
+				"title": "Delete API configuration"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of API configurations"
+			}
+		},
+		"application": {
+			"archive": {
+				"autoDeletedAt": "Automatically removed on",
+				"name": "Name"
+			},
+			"customStyling": "Custom Styling",
+			"dashboard": {
+				"clearFields": "Clear fields",
+				"editFilter": "Edit filter",
+				"empty": "No content available. Wait for your administrator to build some.",
+				"enterEditMode": "Enter edit mode",
+				"enterPreviewMode": "Enter preview mode",
+				"filter": {
+					"empty": "No filters have been defined by the administrators",
+					"filterPosition": {
+						"bottom": "Show filter on the bottom",
+						"left": "Show filter on the left",
+						"right": "Show filter on the right",
+						"top": "Show filter on the top",
+						"unset": "Position unset, please select one"
+					},
+					"info": "Dashboard filters can be used between pages to filter their content.",
+					"title": "Dashboard filters configuration"
+				},
+				"filterSettings": "Filter settings",
+				"settings": {
+					"defaultPosition": "Default position for the filter",
+					"fixedRowHeight": "Row height",
+					"gridOptions": "Grid options",
+					"gridType": {
+						"fit": "Fit",
+						"placeholder": "Select a grid type",
+						"title": "Grid type",
+						"verticalFixed": "Vertical fixed"
+					},
+					"help": {
+						"minCols": "Reducing the number of columns may not have a direct impact if the dashboard contains widgets wider than the specified limit."
+					},
+					"margin": "Margin between widgets",
+					"minCols": "Number of columns",
+					"minimumHeight": "Minimum height",
+					"tooltip": {
+						"fixedRowHeight": "Size of rows in pixels.\nMust be greater or equal to 50.",
+						"margin": "Gap in pixels between widgets.\nMust be a positive integer.",
+						"minCols": "Number of columns.\nMust be an integer between 4 and 24.",
+						"minimumHeight": "Minimum height of the grid in pixels.\nMust be greater than or equal to 0. \nThe dashboard won't automatically fit to the screen if its height is below this number.",
+						"reset": "Reset to default"
+					}
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the application {{name}}?"
+			},
+			"duplicate": {
+				"name": {
+					"description": "Please enter a description for the application"
+				}
+			},
+			"pages": {
+				"delete": {
+					"confirmationMessage": "Do you confirm the deletion of the page {{name}}?"
+				},
+				"hide": "Hide page in nav bar for end-users",
+				"notReordered": {
+					"plural": "The pages were not reordered. {{error}}",
+					"singular": "The page was not reordered. {{error}}"
+				},
+				"reordered": {
+					"plural": "The pages were successfully reordered.",
+					"singular": "The page was successfully reordered."
+				},
+				"settings": {
+					"actions": "Actions",
+					"goNextStepOnSave": "Go to next step on save",
+					"selectIcon": "Select an icon",
+					"tooltip": {
+						"autoSave": "Changes are automatically saved"
+					}
+				},
+				"show": "Make page visible in nav bar for end-users"
+			},
+			"positionAttribute": {
+				"delete": {
+					"confirmationMessage": "Do you confirm the deletion of the position attribute {{name}}?",
+					"title": "Delete position attribute"
+				}
+			},
+			"publish": {
+				"confirmationMessage": "Do you confirm the publication of {{name}} application?",
+				"title": "Publish application"
+			},
+			"subscription": {
+				"modal": {
+					"hint": {
+						"listenTo": "Message broker routing key"
+					},
+					"listenTo": "Listen to",
+					"placeholder": {
+						"listenTo": "Select a routing key"
+					},
+					"routingKey": {
+						"clear": {
+							"ariaLabel": "Clear routing key"
+						}
+					}
+				}
+			},
+			"unlock": {
+				"confirmationMessage": "Do you want to unlock edition of {{name}}?",
+				"title": "Unlock edition"
+			},
+			"update": {
+				"hideMenu": "Hide menu by default",
+				"placeholder": {
+					"description": "Please enter a description for the application"
+				},
+				"sideMenu": "Show menu on the side",
+				"tooltip": {
+					"hideMenu": "Only applies when menu is located on the side"
+				}
+			},
+			"users": {
+				"auto": "Automatically assigned",
+				"empty": "No user detected",
+				"manual": "Manually assigned"
+			}
+		},
+		"applications": {
+			"dropdown": {
+				"select": "From applications"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of applications"
+			}
+		},
+		"calculatedFields": {
+			"add": "Create a new Calculated field",
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the Calculated field {{name}}?"
+			},
+			"edit": "Edit Calculated field",
+			"expression": "Expression",
+			"hint": {
+				"name": "Enter an unique name only composed of letters, digits and underscores. This name should not override any field name of current resource."
+			}
+		},
+		"channel": {
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the channel {{name}}?"
+			},
+			"dropdown": {
+				"select": "Notify on"
+			},
+			"selectChannel": "Select a channel"
+		},
+		"confirmModal": {
+			"cancel": "Cancel",
+			"confirm": "Confirm",
+			"delete": "Delete",
+			"title": "Confirm"
+		},
+		"customNotifications": {
+			"edit": {
+				"dataset": "Dataset",
+				"email": "Email notification",
+				"new": "New custom Notification",
+				"recipients": {
+					"distributionList": "Use a distribution list",
+					"email": "Input a single email address",
+					"title": "Recipients",
+					"userField": "Group by dataset user field"
+				},
+				"update": "Edit custom notification"
+			},
+			"errors": {
+				"email": "Please input a valid email address",
+				"schedule": "Enter a valid cron expression"
+			},
+			"hint": {
+				"schedule": "Enter schedule for notification sending"
+			}
+		},
+		"distributionLists": {
+			"delete": {
+				"confirmationMessage": "Are you sure you want to delete the distribution list '{{name}}'?"
+			},
+			"edit": {
+				"name": "Distribution list name",
+				"new": "New distribution list",
+				"update": "Edit distribution list"
+			},
+			"errors": {
+				"emails": {
+					"pattern": "Please only provide valid emails",
+					"required": "Please provide one or more emails"
+				},
+				"name": {
+					"required": "Please provide a name"
+				}
+			}
+		},
+		"emailBuilder": {
+			"body": "Body",
+			"default": "Default",
+			"fields": "Select fields to write in body",
+			"from": {
+				"distribution": "Distribution list",
+				"field": "Data field",
+				"title": "From:"
+			},
+			"subject": "Subject",
+			"withoutRecords": "Without records"
+		},
+		"emailPreview": {
+			"errors": {
+				"missingSubject": "The subject of the email cannot be empty."
+			},
+			"from": "From",
+			"subject": "Subject",
+			"title": "Email preview",
+			"to": "To"
+		},
+		"form": {
+			"aggregation": {
+				"delete": {
+					"confirmationMessage": "Do you confirm the deletion of the aggregation {{name}}?"
+				}
+			},
+			"create": {
+				"choice": {
+					"inherit": "Create from template",
+					"resource": "Create a core form",
+					"template": "Start from existing template"
+				},
+				"template": {
+					"from": "From template",
+					"placeholder": "Pick an existing template",
+					"selectResource": "Select a resource",
+					"title": "From resource"
+				},
+				"tooltip": {
+					"inherit": "Creates a child form using a template from the resource linked to the core form",
+					"resource": "Creates a core form that allows the creation of children forms linked to this core form. It will also create a new resource.",
+					"template": "If no template is selected, core structure will be loaded"
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the form {{name}}?"
+			},
+			"deleteRow": {
+				"confirmationMessage": "Do you confirm the deletion of {{quantity}} {{rowText}}?"
+			},
+			"display": {
+				"submissionMessage": "The form has successfully been submitted."
+			},
+			"draftRecords": {
+				"buttonLoad": "Load draft record",
+				"confirmModal": {
+					"confirmDelete": "Do you really want to delete this draft record?",
+					"confirmLoad": "Do you really want to load this draft record?",
+					"delete": "Delete this draft",
+					"load": "Load this draft"
+				},
+				"creationDate": "Creation date",
+				"delete": "Delete this draft",
+				"load": "Load this draft",
+				"noDrafts": "No draft available.",
+				"preview": "Preview this draft",
+				"previewTitle": "Draft record",
+				"save": "Save as draft",
+				"select": "Select draft record",
+				"successEdit": "Successfully edited draft",
+				"successSave": "Successfully saved as draft"
+			},
+			"layout": {
+				"delete": {
+					"confirmationMessage": "Do you confirm the deletion of the layout {{name}}?"
+				},
+				"errors": {
+					"invalid": "The form is not valid"
+				},
+				"update": {
+					"preview": {
+						"description": "Reorder, sort, filter and hide columns to edit default display of the layout"
+					}
+				}
+			},
+			"searchExistingRecords": {
+				"matches": "Matches",
+				"noMatches": "No matches found",
+				"openRecordTooltip": "Open record"
+			},
+			"summary": {
+				"cache": {
+					"clear": "Clear cache",
+					"load": "Load from cache {{date}}"
+				},
+				"createdBy": "Created by {{user}} at {{date}}",
+				"modifiedBy": "Last modified by {{user}} on {{date}}"
+			},
+			"update": {
+				"exit": "Exit without saving changes",
+				"exitMessage": "There are unsaved changes on your form. Are you sure you want to exit?"
+			},
+			"updateRow": {
+				"confirmationMessage": "Do you confirm the update of {{quantity}} {{rowText}}?"
+			}
+		},
+		"formBuilder": {
+			"errors": {
+				"duplicatedRelatedName": "Duplicated related name for question {{question}} on page {{page}}. Please provide a unique related name (snake case format) to save the form.",
+				"incorrectJSON": "JSON is invalid in JSON Editor, changes haven't been saved",
+				"missingGridField": "Missing an available field grid for question {{question}} on page {{page}}. Please select a least one in Custom Question Properties to save the form.",
+				"missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",
+				"missingTemplate": "Missing related resource template for question {{question}} on page {{page}}. Please select a template to save the form."
+			},
+			"propertyGrid": {
+				"resource": {
+					"availableGridFields": "Available grid fields",
+					"resourceSelectText": "First you have to select a resource before setting any filters"
+				}
+			},
+			"saveSurvey": "Saving the form"
+		},
+		"formMapProperties": {
+			"geofields": {
+				"editDialog": {
+					"editGeofield": "Edit Geo fields",
+					"label": "Label",
+					"value": "Value"
+				}
+			}
+		},
+		"forms": {
+			"isCore": "Is core",
+			"paginator": {
+				"ariaLabel": "Select page of forms"
+			},
+			"parent": "Parent form"
+		},
+		"group": {
+			"add": {
+				"title": "Add new group"
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the group {{name}}?",
+				"title": "Delete group"
+			}
+		},
+		"header": {
+			"goToApp": "Go to application",
+			"goToPlatform": "Navigate to",
+			"logout": "Logout",
+			"sidenav": {
+				"collapse": "Collapse sidebar",
+				"show": "Show sidebar"
+			}
+		},
+		"history": {
+			"changes": {
+				"add": "Add value",
+				"from": "from",
+				"modify": "Change value",
+				"remove": "Delete value",
+				"to": "to",
+				"withValue": "with value"
+			},
+			"columns": {
+				"action": "Action type",
+				"date": "Date",
+				"modifiedValue": "New value",
+				"originalValue": "Old value",
+				"person": "User",
+				"time": "Time",
+				"variable": "Field"
+			},
+			"download": "Download history",
+			"empty": "No activity detected",
+			"field": {
+				"all": "All fields",
+				"select": "Select fields"
+			},
+			"preview": "Preview and revert",
+			"range": {
+				"clear": "Clear range"
+			},
+			"useTableMode": "Use table mode"
+		},
+		"icon": {
+			"modal": {
+				"select": "Select an icon",
+				"use": "Use icon"
+			}
+		},
+		"logout": {
+			"confirmationMessage": "There are unsaved changes on your form. Are you sure you want to logout?",
+			"title": "Exit without saving changes"
+		},
+		"map": {
+			"controls": {
+				"download": {
+					"layers": {
+						"all": "All layers",
+						"selected": "Selected Layers",
+						"visible": "Visible layers"
+					},
+					"output": "Select an output format",
+					"selectLayers": "Select layers",
+					"view": {
+						"all": "Map",
+						"current": "Current view"
+					}
+				},
+				"timeline": {
+					"show": "Show timeline",
+					"time": {
+						"dateFormat": "Date display",
+						"startField": "Start showing at",
+						"stopField": "Stop showing at",
+						"tooltip": "When enabled, a timeline will be displayed on the map. It will allow you to visualize the evolution of your data over time."
+					},
+					"title": "Timeline"
+				}
+			}
+		},
+		"mapping": {
+			"field": "User field",
+			"path": "Path",
+			"text": "Text",
+			"title": "Mapping",
+			"value": "Value"
+		},
+		"notifications": {
+			"paginator": {
+				"ariaLabel": "Select page of notifications"
+			},
+			"readAll": "Mark all as read",
+			"title": "Notifications"
+		},
+		"paginator": {
+			"items": "items",
+			"itemsPerPage": "items per page",
+			"of": "of",
+			"page": "Page"
+		},
+		"preferences": {
+			"dateFormat": "Date and time format",
+			"language": "Language",
+			"title": "Preferences"
+		},
+		"pullJob": {
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the pull job {{name}}?",
+				"title": "Delete pull job"
+			},
+			"modal": {
+				"addMappingField": "add a mapping field",
+				"errors": {
+					"schedule": "Enter a valid cron expression"
+				},
+				"hint": {
+					"path": "Enter the path to extract data from response",
+					"schedule": "Enter the schedule time for this Pull job",
+					"url": "Enter the URL after the host to reach specific data"
+				},
+				"identifier": "Unique identifiers",
+				"mapping": "Mapping",
+				"placeholder": {
+					"path": "Enter path...",
+					"schedule": "Enter schedule time...",
+					"url": "Enter URL..."
+				},
+				"switch": "Switch mode"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of pull jobs"
+			}
+		},
+		"queryBuilder": {
+			"dataset": {
+				"select": "Select a dataset"
+			},
+			"errors": {
+				"field": {
+					"invalid": "Invalid field. Please click to remove."
+				}
+			},
+			"fields": {
+				"available": "Available fields",
+				"column": "Column width (px)",
+				"format": {
+					"info": "Left empty to ignore formatting",
+					"title": "Display format"
+				},
+				"search": "Search fields...",
+				"selected": "Selected fields",
+				"title": "Fields"
+			},
+			"filter": {
+				"and": "And",
+				"logic": "Filter logic",
+				"new": "Add new filter",
+				"newGroup": "Add new filter group",
+				"operator": "Operator",
+				"or": "Or",
+				"title": "Filter"
+			},
+			"hint": {
+				"fields": "Select data points below and drag them to 'selected fields' on the right",
+				"sortingDisabled": "Sorting fields is disabled when search is active",
+				"style": "Styling rules make records with important information stand out. When a record matches more than one rule, the first rule is used."
+			},
+			"pagination": {
+				"first": "Limit",
+				"title": "Pagination"
+			},
+			"sort": {
+				"ascending": "Ascending",
+				"descending": "Descending",
+				"field": "Sort field",
+				"limit": "limit",
+				"limitTitle": "Sort & Limit",
+				"order": "Sort order",
+				"title": "Sort"
+			},
+			"style": {
+				"and": "And",
+				"edit": {
+					"appliesTo": "Apply style to",
+					"background": {
+						"color": "Background color"
+					},
+					"criteria": "Rule criteria",
+					"fields": "Fields",
+					"name": "Rule name",
+					"selectedColumns": "Only selected columns",
+					"text": {
+						"color": "Text color",
+						"style": "Text style"
+					},
+					"wholeRow": "Whole row"
+				},
+				"logic": "Style filter",
+				"new": "Add styling rule",
+				"operator": "Operator",
+				"or": "Or",
+				"title": "Style"
+			},
+			"tooltip": {
+				"filter": {
+					"date": {
+						"useExpression": "Use Expression editor",
+						"usePicker": "Use Date picker"
+					}
+				},
+				"pagination": {
+					"first": "If provided, limit the number of queried items"
+				}
+			}
+		},
+		"record": {
+			"attach": {
+				"confirm": "Attach",
+				"selectTarget": "Select {{name}} target"
+			},
+			"convert": {
+				"choice": {
+					"copy": "Copy source record",
+					"overwrite": "Overwrite source record"
+				},
+				"result": {
+					"force": "Following fields will be ignored:",
+					"smooth": "Conversion OK"
+				},
+				"select": "Convert to"
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the record {{name}}?",
+				"permanently": "Delete permanently"
+			},
+			"dropdown": {
+				"select": "Select record"
+			},
+			"history": {
+				"revert": "Revert to past record",
+				"version": {
+					"current": "Current version",
+					"old": "Past version"
+				}
+			},
+			"modal": {
+				"closeConfirmation": "Close without saving changes?",
+				"update": "Save and close"
+			},
+			"recovery": {
+				"confirmationMessage": "Do you confirm recovery the data from {{date}} to the current register?",
+				"title": "Recovery data"
+			}
+		},
+		"records": {
+			"active": "Active records",
+			"archived": "Archived records",
+			"editAs": "Edit as",
+			"paginator": {
+				"ariaLabel": "Select page of records"
+			},
+			"showActive": "Show active records",
+			"showArchived": "Show archived records",
+			"upload": {
+				"hint": "File should contain one record per row. Header row contains the names of data fields."
+			}
+		},
+		"referenceData": {
+			"create": {
+				"title": "New Reference Data"
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of Reference Data {{name}}?",
+				"title": "Delete Reference Data"
+			},
+			"dropdown": {
+				"select": "From Reference data"
+			},
+			"fields": {
+				"add": "Add field",
+				"ariaLabel": "Input available fields of reference data",
+				"new": "New field"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of reference data"
+			}
+		},
+		"resource": {
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the resource {{name}}?"
+			},
+			"dropdown": {
+				"select": "From resource"
+			},
+			"empty": {
+				"aggregations": "No aggregation detected",
+				"calculatedFields": "No calculated fields detected",
+				"layouts": "No layout detected",
+				"records": "No record detected"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of resources"
+			}
+		},
+		"role": {
+			"add": {
+				"title": "Add new role"
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the role {{name}}?",
+				"title": "Delete role"
+			},
+			"impersonate": {
+				"title": "Choose role to simulate"
+			},
+			"summary": {
+				"addFilter": "Add filter",
+				"autoAssignment": {
+					"rule": {
+						"add": "Create assignment rule",
+						"delete": "Delete rule",
+						"edit": "Edit assignment rule",
+						"none": "No assignment rule",
+						"title": "Rule"
+					},
+					"title": "Automatic assignment"
+				},
+				"details": {
+					"access": {
+						"channels": "Channels access",
+						"fullAccess": "Full access to {{accessible}} / {{total}}",
+						"limitedAccess": "Limited access to {{accessible}} / {{total}}",
+						"noAccess": "No access to {{accessible}} / {{total}}",
+						"pages": "Pages access",
+						"resources": "Resources access",
+						"title": "Access summary"
+					}
+				},
+				"editFilters": "Edit filters",
+				"features": "Features",
+				"newFilter": "New filter",
+				"noFeatures": "No feature detected",
+				"noFilters": "No access filters detected",
+				"noForms": "No forms detected",
+				"noSteps": "No steps detected",
+				"removeFilter": "Remove filter",
+				"title": "Summary",
+				"users": {
+					"auto": "Automatically assigned",
+					"empty": "No user detected",
+					"manual": "Manually assigned"
+				}
+			},
+			"tooltip": {
+				"allowFieldAccessibility": "Allow this role to see the field {{field}}",
+				"allowFieldUpdate": "Allow this role to update the field {{field}}",
+				"disallowFieldAccessibility": "Disallow this role to see the field {{field}}",
+				"disallowFieldUpdate": "Disallow this role to update the field {{field}}",
+				"grantAddRecordsPermission": "Grant permission to add new records",
+				"grantDeleteRecordsPermission": "Grant permission to delete records",
+				"grantFilterDeleteRecordsPermission": "Grant permission to delete records that satisfies filter",
+				"grantFilterReadRecordsPermission": "Grant permission to see records that satisfies filter",
+				"grantFilterUpdateRecordsPermission": "Grant permission to update records that satisfies filter",
+				"grantReadRecordsPermission": "Grant permission to see records",
+				"grantUpdateRecordsPermission": "Grant permission to update records",
+				"hideFeature": "Hide {{page}} from this role",
+				"limitedDeleteRecordsPermission": "Provide limited permission to delete records, based on filters",
+				"limitedReadRecordsPermission": "Provide limited permission to see records, based on filters",
+				"limitedUpdateRecordsPermission": "Provide limited permission to update records, based on filters",
+				"notGrantAddRecordsPermission": "Does not grant permission to add new records",
+				"notGrantDeleteRecordsPermission": "Does not grant permission to delete records",
+				"notGrantFilterDeleteRecordsPermission": "Does not grant permission to delete records that satisfies filter",
+				"notGrantFilterReadRecordsPermission": "Does not grant permission to see records that satisfies filter",
+				"notGrantFilterUpdateRecordsPermission": "Does not grant permission to update records that satisfies filter",
+				"notGrantReadRecordsPermission": "Does not grant permission to see records",
+				"notGrantUpdateRecordsPermission": "Does not grant permission to update records",
+				"showFeature": "Show {{page}} to this role"
+			},
+			"update": {
+				"permissions": "Permissions",
+				"title": "Update role permissions and channels"
+			}
+		},
+		"share": {
+			"modal": {
+				"copy": "Copy to clipboard",
+				"title": "Share dashboard url"
+			}
+		},
+		"templates": {
+			"available": "Available email templates",
+			"delete": {
+				"confirmationMessage": "Are you sure you want to delete the template '{{name}}'?"
+			},
+			"edit": {
+				"body": "Body",
+				"name": "Template name",
+				"new": "New notification template",
+				"subject": "Subject",
+				"update": "Edit notification template"
+			},
+			"errors": {
+				"empty": "Please select one or more templates"
+			},
+			"select": {
+				"email": "Select an email template"
+			},
+			"type": {
+				"email": "Email",
+				"title": "Template type"
+			}
+		},
+		"user": {
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the user {{name}}?",
+				"title": "Delete user"
+			},
+			"invite": {
+				"confirm": "Invite",
+				"role": {
+					"additionalAttributes": "Set additional attributes",
+					"description": "Select the role to assign"
+				}
+			},
+			"summary": {
+				"country": "Country",
+				"firstName": "First name",
+				"lastName": "Last name",
+				"locationType": "Location type",
+				"region": "Region",
+				"roles": {
+					"application": "Application roles",
+					"backoffice": "Back-Office roles",
+					"selectedApplication": "Selected application",
+					"selectedGroups": "Selected groups",
+					"selectedRoles": "Selected roles"
+				},
+				"title": "Summary"
+			},
+			"update": {
+				"title": "Update user"
+			}
+		},
+		"users": {
+			"invite": {
+				"add": "Add new user",
+				"confirm": "Invite users",
+				"description": "Select existing users, invite new users or import from Excel file"
+			},
+			"onDelete": {
+				"plural": "Users were correctly deleted.",
+				"singular": "User was correctly deleted."
+			},
+			"onInvite": {
+				"plural": "Users were invited.",
+				"singular": "User was invited."
+			},
+			"onNotDelete": {
+				"plural": "Users were not deleted. {{error}}",
+				"singular": "User was deleted. {{error}}"
+			},
+			"onNotInvite": {
+				"plural": "Users were not invited. {{error}}",
+				"singular": "User was not invited. {{error}}"
+			},
+			"paginator": {
+				"ariaLabel": "Select page of users"
+			}
+		},
+		"widget": {
+			"chart": {
+				"errors": {
+					"aggregation": {
+						"invalid": "Invalid aggregation"
+					}
+				},
+				"filters": {
+					"select": "Select a filter..."
+				},
+				"other": "Other"
+			},
+			"display": {
+				"tooltip": {
+					"placeholder": "Enter a value for tooltip"
+				}
+			},
+			"expand": "Expand",
+			"grid": {
+				"actions": {
+					"detail": "Open detail",
+					"downloadReport": "Download",
+					"goTo": "Go to page",
+					"history": "Show history"
+				},
+				"errors": {
+					"autoSaveFailed": "Action stopped due to some invalid records. Please review them before taking any other action.",
+					"invalid": {
+						"backoffice": "Invalid grid configuration",
+						"frontoffice": "Invalid grid configuration, please contact your admin",
+						"widgets": "Invalid grid configuration, please contact your admin"
+					},
+					"metaQueryBuildFailed": "Error building metadata",
+					"metaQueryFetchFailed": "Error fetching metadata: {{error}}",
+					"missingDataset": "Select a dataset in settings",
+					"noRowsSelected": "No rows selected",
+					"queryBuildFailed": "Error building query",
+					"queryFetchFailed": "Error fetching data: {{error}}",
+					"validationFailed": "The following records could not be saved due to validation rules:\n{{errors}}\nPlease edit the record using the 'update' button for more details."
+				},
+				"export": {
+					"columns": {
+						"choice": {
+							"all": "All available columns",
+							"visible": "Only visible columns"
+						},
+						"title": "Select columns to export"
+					},
+					"dataset": {
+						"choice": {
+							"all": "All records in view",
+							"selected": "Only selected records"
+						},
+						"title": "Select records to export"
+					},
+					"email": {
+						"title": "Send me the file by email",
+						"tooltip": "If checked, instead of waiting for the export to be fully built before downloading it, you will receive an email with the export attached once it's ready."
+					},
+					"format": {
+						"title": "Select export format"
+					}
+				},
+				"filter": {
+					"toggle": "Toggle visibility of filter"
+				},
+				"item": {
+					"few": "{{count}} items",
+					"none": "No item",
+					"one": "{{count}} item"
+				},
+				"layout": {
+					"button": {
+						"title": "This will erase current layout with default layout"
+					},
+					"reset": "Reset default Layout"
+				},
+				"loading": {
+					"records": "Loading records...",
+					"settings": "Loading settings..."
+				},
+				"map": {
+					"mapDetailsTitle": "Query Map View",
+					"mapDetailsTooltip": "Centered by default on selected record"
+				},
+				"openSettings": "Open settings",
+				"tooltip": {
+					"displayMap": "Display map",
+					"openPage": "Navigate to page",
+					"saved": "Changes saved",
+					"unsaved": "Click on save button to upload changes",
+					"uploadFailed": "Record not saved. Click to see more details"
+				},
+				"validation": {
+					"help": "Please edit the record using the 'update' button for more details.",
+					"questionTitle": "Errors on field {{question}}:",
+					"subtitle": "These errors where found while saving changes:",
+					"title": "Validation failed for record {{record}}"
+				}
+			},
+			"settings": {
+				"chart": {
+					"auto": "auto",
+					"axes": "Axes",
+					"categories": "Categories",
+					"color": "Color",
+					"filters": {
+						"add": "Add filter",
+						"delete": "Delete filter",
+						"empty": "No filters configured",
+						"title": "Predefined filters"
+					},
+					"grid": {
+						"buttons": {
+							"modifySelectedRows": {
+								"confirmation": "Are you sure you want to modify the selected rows?"
+							}
+						},
+						"title": "Gridlines",
+						"x": {
+							"display": "Display horizontal gridlines"
+						},
+						"y": {
+							"display": "Display vertical gridlines"
+						}
+					},
+					"hideLegend": "Hide legend",
+					"labels": {
+						"percentage": "Percentage",
+						"showCategory": "Show category labels",
+						"showValue": "Show value labels",
+						"title": "Labels",
+						"valueType": "Value type"
+					},
+					"legend": "Legend",
+					"orientation": "Orientation",
+					"other": "Other",
+					"palette": {
+						"enable": "Use Custom Palette",
+						"title": "Color palette"
+					},
+					"position": "Position",
+					"series": {
+						"fill": "Fill",
+						"interpolation": {
+							"step": "Step interpolation",
+							"title": "Interpolation"
+						},
+						"showSeries": "Show series",
+						"stack": {
+							"enable": "Plot series",
+							"usePercentage": "Use percentage"
+						},
+						"title": "Series"
+					},
+					"size": "Size",
+					"stepSize": "Step size",
+					"style": "Style",
+					"text": "Text",
+					"title": {
+						"color": "Title color",
+						"format": "Title format"
+					},
+					"tooltip": {
+						"palette": "Palette provides default colors to chart elements if not manually set.",
+						"stepSize": "Interval between each tick mark on the chart's axis, when possible"
+					},
+					"type": "Chart Type",
+					"xAxis": "X Axis",
+					"yAxis": "Y Axis"
+				},
+				"close": {
+					"confirmationMessage": "Some changes will be lost when closing edition. Do you want to continue?"
+				},
+				"editor": {
+					"recordSelection": "Record selection",
+					"title": "Editor"
+				},
+				"grid": {
+					"actions": {
+						"add": "Add new records",
+						"convert": "Convert records",
+						"delete": "Delete records",
+						"export": "Export records",
+						"goTo": {
+							"column": {
+								"label": "Column name",
+								"placeholder": "Type a title for the column..."
+							},
+							"field": {
+								"label": "Pass field as query parameter",
+								"placeholder": "Select a field"
+							},
+							"label": "Navigate to page",
+							"target": {
+								"label": "Target page",
+								"placeholder": "Select a page"
+							}
+						},
+						"inline": "Inline edition",
+						"navigateToPage": "Navigate to page",
+						"pageUrl": {
+							"label": "Target page",
+							"placeholder": "Select a page"
+						},
+						"pageUrlTitle": {
+							"label": "Column name",
+							"placeholder": "Type a title for the column..."
+						},
+						"remove": "Remove",
+						"show": "Show history",
+						"showDetails": "Show record details",
+						"title": "Enabled actions",
+						"update": "Update records",
+						"useRecordId": "Pass id as query parameter"
+					},
+					"aggregations": {
+						"add": {
+							"choice": {
+								"create": "Create a new aggregation"
+							}
+						},
+						"title": "Grid aggregations"
+					},
+					"buttons": {
+						"callback": {
+							"attach": "Attach to record",
+							"displayField": "Display field",
+							"export": "Export selected dataset",
+							"modify": "Auto-modify selected rows",
+							"modifyField": "Field to update",
+							"modifyValue": "Value to attribute",
+							"notify": {
+								"message": "Notification message"
+							},
+							"prefill": "Pre-fill form with selected data",
+							"save": "Auto-save",
+							"selectAllRecords": "Select all records",
+							"selectAllRecordsActivePage": "Select all records on the active page",
+							"selectDisplay": "Select displayed fields",
+							"sendMail": "Send mail",
+							"workflow": {
+								"close": "Close workflow",
+								"confirm": "Confirmation message",
+								"next": "Go to next step",
+								"previous": "Go to previous step"
+							}
+						},
+						"create": "Add a button",
+						"defaultName": "Action button",
+						"enable": "Enable",
+						"placeholder": {
+							"modifyValue": "Set as null"
+						},
+						"requireConfirmation": "Require confirmation",
+						"title": "Quick action buttons",
+						"tooltip": {
+							"attach": "When enabled, you must provide a form and a field of this form. All selected rows will be attached to a record from this form. The user will be able to choose which record using a the given field",
+							"mail": {
+								"selectDistributionList": "Select the distribution list that will set recipients of the email",
+								"selectTemplates": "Select the email templates users will be allowed to choose from when using the action"
+							},
+							"notify": "When enabled, you must provide a channel and a message. All selected rows will be sent as a single notification on the specified channel. The provided message is used to define the notification’s action",
+							"publish": "When enabled, you must provide a channel. All selected rows will be sent as a single publication on the specified channel. Everyone listening to this channel can receive the records"
+						}
+					},
+					"display": {
+						"actionsTitle": "Display actions title",
+						"injectClasses": {
+							"title": "Inject values as CSS classes",
+							"tooltip": "When a field is selected, it's value will be added to to <tr> element as a class, allowing it to be targeted by custom styling"
+						},
+						"showSingleActionAsButton": "Show single action as button"
+					},
+					"hint": {
+						"actions": {
+							"add": "If authorized, user can add new records using selected template",
+							"convert": "If authorized, user can convert record using another template of selected resource",
+							"delete": "If authorized, user can delete visible records",
+							"export": "User can export selected columns of visible records",
+							"goTo": "User can go to specified page on click",
+							"inline": "If authorized, user can edit records in the grid",
+							"navigateToPage": "User can go to specified page on click",
+							"show": "User can see full history of visible records",
+							"showDetails": "User can see full details of visible records",
+							"update": "If authorized, user can update visible records"
+						},
+						"attachToRecord": "If the selected records are not attached to any records, the action will be canceled",
+						"buttons": "Quick action buttons will appear on the widget and allow you to complete any of the actions below",
+						"executionOrder": "Selected actions will be executed in the displayed order",
+						"prefillForm": "If no record is created at this point, the action will be canceled"
+					},
+					"layouts": {
+						"add": {
+							"choice": {
+								"create": "Create a new layout",
+								"load": "Load existing layout"
+							},
+							"title": "Add new layout"
+						},
+						"edit": {
+							"title": "Layout configuration"
+						},
+						"select": "Select a layout",
+						"title": "Grid layouts"
+					},
+					"tooltip": {
+						"template": "Select a template for addition and edition of records",
+						"useRecordId": "Url will contain id of the item, in order to redirect to contextual page, if configured"
+					},
+					"warnings": {
+						"add": "Please select a template",
+						"general": "Warning: actions contain errors"
+					}
+				},
+				"iconPicker": {
+					"default": "Default",
+					"placeholder": "Click to select an icon"
+				},
+				"map": {
+					"basemap": "Base map",
+					"category": "Map quick layers",
+					"dataset": "Data set selection",
+					"edit": {
+						"aggregation": "Aggregation",
+						"cluster": {
+							"autoSizeCluster": "Cluster auto-sizing",
+							"cluster": "Cluster",
+							"clusterSettings": "Cluster settings",
+							"clustering": "Clustering",
+							"fields": "Cluster fields",
+							"font": "Font",
+							"fontSize": "Font size",
+							"high": "High",
+							"label": "Cluster label",
+							"lightMode": "Light mode",
+							"low": "Low",
+							"max": "Max",
+							"min": "Min",
+							"overrideSymbol": "Override cluster symbol",
+							"popups": "Cluster pop-ups",
+							"radius": "Cluster radius",
+							"sizeRange": "Size range",
+							"symbol": "Symbol style"
+						},
+						"datasource": {
+							"origin": "Origin"
+						},
+						"fields": "Fields",
+						"filter": "Filter",
+						"groupLayers": "Group layers",
+						"labels": "Labels",
+						"layerDatasource": "Layer datasource",
+						"layerEdition": "Layer edition",
+						"layerProperties": "Layer properties",
+						"layerStyling": "Layer styling",
+						"popup": "Pop-up",
+						"properties": {
+							"defaultVisibility": "Visible by default",
+							"from": "from zoom ",
+							"opacity": "Opacity",
+							"to": " to zoom",
+							"visibilityRange": "Visibility range",
+							"zoom": "Current zoom"
+						},
+						"reduction": {
+							"noReduction": "No reduction",
+							"reduction": "Reduction"
+						},
+						"style": {
+							"color": "Color",
+							"fieldForSize": "Size based on field",
+							"icon": "Icon",
+							"size": "Size",
+							"stylingType": "{{layerType}} styling"
+						},
+						"styling": {
+							"heatmapOptions": {
+								"blur": "Blur",
+								"gradient": "Gradient",
+								"minOpacity": "Minimum opacity",
+								"radius": "Radius"
+							}
+						}
+					},
+					"errors": {
+						"latitude": "Invalid latitude, please select a number between -90 and 90",
+						"longitude": "Invalid longitude, please select a number between -180 and 180"
+					},
+					"geospatial": {
+						"layersStyles": {
+							"fill": {
+								"color": "Fill color",
+								"opacity": "Fill opacity",
+								"title": "Fill"
+							},
+							"marker": {
+								"color": "Marker color",
+								"opacity": "Marker opacity",
+								"title": "Marker"
+							},
+							"outline": {
+								"color": "Outline color",
+								"opacity": "Outline opacity",
+								"title": "Outline",
+								"width": "Outline width"
+							},
+							"title": "Layer styles"
+						}
+					},
+					"layers": {
+						"add": "Add new layer",
+						"chooseLayer": "Choose a layer",
+						"createGroup": "Create a new group layer",
+						"createLayer": "Create a new layer",
+						"dataSource": {
+							"fieldMapping": "Field Mapping",
+							"geoField": "GeoField",
+							"latitude": "Latitude",
+							"longitude": "Longitude"
+						},
+						"edit": "Update layer {{name}}",
+						"online": {
+							"info": "Search for online layers in arcGIS online",
+							"select": "Search layers",
+							"selected": "Selected layers",
+							"title": "Online layers"
+						},
+						"point": {
+							"addNew": "Add new marker rule",
+							"category": "Map quick layers",
+							"color": "Color",
+							"info": "Display markers in the map for each entry of your data, binding dataset number fields to geolocation",
+							"rules": "Marker rules",
+							"rulesInfo": "Customize the size and colors of your markers",
+							"size": "Size",
+							"title": "Marker layers"
+						},
+						"popup": {
+							"addField": "Add field",
+							"description": "Description",
+							"fields": "Fields",
+							"fieldsElements": {
+								"description": "Description",
+								"title": "Title"
+							},
+							"popup": "Popup",
+							"popupElements": "Popup elements",
+							"text": "Text",
+							"title": "Title",
+							"tooltip": {
+								"text": "Type '{' to start using fields from the datasource"
+							}
+						},
+						"remove": "Remove layer",
+						"selectLayer": "Select existing layer",
+						"styling": {
+							"style": "Style"
+						},
+						"types": {
+							"cluster": "cluster",
+							"heatmap": "heatmap",
+							"point": "point",
+							"polygon": "polygon"
+						}
+					},
+					"legend": {
+						"high": "High",
+						"low": "Low",
+						"title": "Legend"
+					},
+					"popup": {
+						"label": "Fields displayed in the popup",
+						"location": "Location",
+						"of": "{{current}} of {{total}}",
+						"zoomTo": "Zoom to"
+					},
+					"properties": {
+						"basemap": "Base map",
+						"controls": {
+							"download": "Download",
+							"lastUpdate": "Last updated on",
+							"lastUpdateError": "Last modified time could not be loaded",
+							"lastUpdatePosition": "Select a position to display the control",
+							"layer": "Layers",
+							"legend": "Legend",
+							"measure": "Measure",
+							"search": "Search",
+							"timedimension": "Time dimension",
+							"title": "Visible Map Controls"
+						},
+						"geographicExtent": "Geographic extent",
+						"geographicExtentValue": "Geographic extent value",
+						"latitude": "Map center latitude",
+						"longitude": "Map center longitude",
+						"setByMap": "Set By Map",
+						"title": "Map Parameters",
+						"webmap": "WebMap",
+						"zoom": "Default zoom"
+					},
+					"renderer": {
+						"default": "Default",
+						"defaultLabel": "Default label",
+						"label": "Label",
+						"symbol": "Symbol",
+						"uniqueValue": "Unique values",
+						"value": "Value"
+					},
+					"tooltip": {
+						"category": "Selecting a field will separate your records into different layers, accessible on top right corner of the map",
+						"cluster": {
+							"autoSize": "If enabled, size of clusters is automated. Else, you can select one.",
+							"lightMode": "If enabled, label uses white. Else, it displays in black."
+						},
+						"dataset": "Select data points below and drag them to 'selected fields' on the right. They will be displayed in the pop-up when clicking on a marker",
+						"default": {
+							"latitude": "Set the default latitude of the center of the map. You can use 'Set By Map' to use the latitude of the preview map.",
+							"longitude": "Set the default longitude of the center of the map. You can use 'Set By Map' to use the longitude of the preview map.",
+							"zoom": "Select a default zoom for the map display"
+						},
+						"geographicExtent": "You can input a static value, or use {{context}} or {{filter}} notation to dynamically inject a value"
+					}
+				},
+				"style": {
+					"customStyling": "Custom Styling"
+				},
+				"summaryCard": {
+					"add": "Add new card",
+					"card": {
+						"dataSource": {
+							"layoutStyles": {
+								"queryFilters": {
+									"help": "Make sure to remove all unused variables, to prevent null arguments to be sent.",
+									"noVariables": "No variables defined",
+									"refresh": "See all graphQL variables",
+									"title": "GraphQL variable mapping",
+									"tooltip": "Set values for the GraphQL variables defined in the reference data query. You can get values from the filters using the {{filter.<question-name>}} templates. E.g.: { \"region\": {{filter.region}} }"
+								},
+								"title": "Layout styles",
+								"use": "Use layout styles",
+								"wholeRow": {
+									"option1": "Apply to all fields",
+									"option2": "Apply to the whole card",
+									"title": "Whole row styles:"
+								}
+							},
+							"title": "Data source"
+						},
+						"display": {
+							"dataSource": "Show link to data source",
+							"header": "Header",
+							"padding": "Use card inner padding",
+							"title": "Card display",
+							"tooltip": {
+								"datasource": "Add a button in widget's header to view card's data source"
+							}
+						},
+						"gridActions": {
+							"title": "Grid actions",
+							"tooltip": "Enabled grid actions"
+						},
+						"preview": {
+							"title": "Preview"
+						},
+						"textEditor": {
+							"alert": "You can add variables e.g: {{data.variable}} and calculate e.g: {{calc.round( value ; precision )}}",
+							"title": "Text editor"
+						},
+						"title": "Card settings",
+						"valueSelector": {
+							"title": "Value selector"
+						}
+					},
+					"create": {
+						"choice": {
+							"blank": "Start from blank",
+							"template": "Start from template"
+						}
+					},
+					"dynamic": "Dynamic",
+					"exportable": "Allow export of the cards",
+					"gridMode": "Allow to show as grid",
+					"hint": {
+						"dynamic": "Dynamic Summary cards adapt their display to the number of elements in the datasource. You must define a single card which will be repeated for each element."
+					},
+					"loadMore": {
+						"infiniteScroll": "Use infinite scrolling",
+						"pagination": "Use pagination",
+						"title": "Trigger for loading more data"
+					},
+					"options": {
+						"ariaLabel": "Select an option"
+					},
+					"static": "Static"
+				},
+				"tabs": {
+					"addNewTab": "Add a new tab",
+					"deleteTab": "Delete tab"
+				}
+			},
+			"styling": "Edit styling",
+			"summaryCard": {
+				"dataSource": "Data Source",
+				"errors": {
+					"invalidSource": "The data source is invalid: please edit the settings."
+				},
+				"viewAsCards": "View as cards",
+				"viewAsGrid": "View as grid"
+			},
+			"text": {
+				"aggregations": {
+					"alert": "You can build custom aggregations and inject them in the editor using {{aggregation.<id>}} placeholders.",
+					"template": {
+						"add": "Add new template aggregation",
+						"edit": "Edit template aggregation"
+					}
+				}
+			}
+		}
+	},
+	"kendo": {
+		"combobox": {
+			"clearTitle": "Clear value",
+			"noDataText": "No available choice"
+		},
+		"datepicker": {
+			"dateFormat": "YYYY/MM/DD or expression ({{today}} or {{now}})",
+			"dateLabel": "Select a date",
+			"endLabel": "Select a end date",
+			"startLabel": "Select a start date",
+			"today": "Today",
+			"toggle": "Choose a date"
+		},
+		"datetimepicker": {
+			"accept": "Accept",
+			"acceptLabel": "Accept",
+			"cancel": "Cancel",
+			"cancelLabel": "Cancel",
+			"dateTab": "Date",
+			"dateTabLabel": "Date",
+			"now": "Now",
+			"timeTab": "Time",
+			"timeTabLabel": "Time",
+			"today": "Today",
+			"toggle": "Choose a date and a time"
+		},
+		"editor": {
+			"addColumnAfter": "Add column after",
+			"addColumnBefore": "Add column before",
+			"addRowAfter": "Add row after",
+			"addRowBefore": "Add row before",
+			"alignCenter": "Center text",
+			"alignJustify": "Justify",
+			"alignLeft": "Align text left",
+			"alignRight": "Align text right",
+			"backColor": "Background color",
+			"bold": "Bold",
+			"cleanFormatting": "Clean formatting",
+			"createLink": "Insert link",
+			"deleteColumn": "Delete column",
+			"deleteRow": "Delete row",
+			"deleteTable": "Delete table",
+			"dialogApply": "Apply",
+			"dialogCancel": "Cancel",
+			"dialogInsert": "Insert",
+			"dialogUpdate": "Update",
+			"fileText": "Text",
+			"fileTitle": "Title",
+			"fileWebAddress": "Web address",
+			"fontFamily": "Select font family",
+			"fontSize": "Select font size",
+			"foreColor": "Color",
+			"format": "Format",
+			"imageAltText": "Alternate text",
+			"imageHeight": "Height (px)",
+			"imageWebAddress": "Web address",
+			"imageWidth": "Width (px)",
+			"indent": "Indent",
+			"insertFile": "Insert file",
+			"insertImage": "Insert image",
+			"insertOrderedList": "Insert ordered list",
+			"insertTable": "Insert Table",
+			"insertUnorderedList": "Insert unordered list",
+			"italic": "Italic",
+			"linkOpenInNewWindow": "Open link in new window",
+			"linkText": "Text",
+			"linkTitle": "Title",
+			"linkWebAddress": "Web address",
+			"outdent": "Outdent",
+			"print": "Print",
+			"redo": "Redo",
+			"selectAll": "Select All",
+			"strikethrough": "Strikethrough",
+			"subscript": "Subscript",
+			"superscript": "Superscript",
+			"underline": "Underline",
+			"undo": "Undo",
+			"unlink": "Remove Link",
+			"unselectAll": "Unselect all",
+			"viewSource": "View source"
+		},
+		"fileselect": {
+			"dropFilesHere": "Drop files here to select",
+			"select": "Select files..."
+		},
+		"grid": {
+			"columnMenu": "'{columnName} Column Menu'",
+			"columns": "Columns",
+			"columnsApply": "Apply",
+			"columnsReset": "Reset",
+			"detailCollapse": "Collapse Details",
+			"detailExpand": "Expand Details",
+			"filter": "Filter",
+			"filterAfterOperator": "Is after",
+			"filterAfterOrEqualOperator": "Is after or equal to",
+			"filterAndLogic": "And",
+			"filterBeforeOperator": "Is before",
+			"filterBeforeOrEqualOperator": "Is before or equal to",
+			"filterBooleanAll": "(All)",
+			"filterClearButton": "Clear",
+			"filterContainsOperator": "Contains",
+			"filterDateToday": "Today",
+			"filterDateToggle": "Toggle calendar",
+			"filterEndsWithOperator": "Ends with",
+			"filterEqOperator": "Is equal to",
+			"filterFilterButton": "Filter",
+			"filterGtOperator": "Is greater than",
+			"filterGteOperator": "Is greater than or equal to",
+			"filterInputLabel": "'{columnName} Filter'",
+			"filterIsEmptyOperator": "Is empty",
+			"filterIsFalse": "is false",
+			"filterIsInOperator": "Is in",
+			"filterIsNotEmptyOperator": "Is not empty",
+			"filterIsNotInOperator": "Is not in",
+			"filterIsNotNullOperator": "Is not null",
+			"filterIsNullOperator": "Is null",
+			"filterIsTrue": "is true",
+			"filterLtOperator": "Is less than",
+			"filterLteOperator": "Is less than or equal to",
+			"filterMenuLogicDropDownLabel": "'{columnName} Filter Logic'",
+			"filterMenuOperatorsDropDownLabel": "'{columnName} Filter Operators'",
+			"filterMenuTitle": "'{columnName} Filter Menu'",
+			"filterNotContainsOperator": "Does not contain",
+			"filterNotEqOperator": "Is not equal to",
+			"filterNumericDecrement": "Decrease value",
+			"filterNumericIncrement": "Increase value",
+			"filterOrLogic": "Or",
+			"filterStartsWithOperator": "Starts with",
+			"gridLabel": "Data table",
+			"groupCollapse": "Collapse Group",
+			"groupExpand": "Expand Group",
+			"groupPanelEmpty": "Drag a column header and drop it here to group by that column",
+			"loading": "Loading",
+			"lock": "Lock",
+			"noRecords": "No records available.",
+			"pagerFirstPage": "Go to the first page",
+			"pagerItems": "items",
+			"pagerItemsPerPage": "items per page",
+			"pagerLabel": "'Page navigation, page {currentPage} of {totalPages}'",
+			"pagerLastPage": "Go to the last page",
+			"pagerNextPage": "Go to the next page",
+			"pagerOf": "of",
+			"pagerPage": "Page",
+			"pagerPageNumberInputTitle": "Page Number",
+			"pagerPreviousPage": "Go to the previous page",
+			"selectAllCheckboxLabel": "Select All Rows",
+			"selectionCheckboxLabel": "Select Row",
+			"setColumnPosition": "Set Column Position",
+			"sortAscending": "Sort Ascending",
+			"sortDescending": "Sort Descending",
+			"sortable": "Sortable",
+			"sortedAscending": "Sorted ascending",
+			"sortedDefault": "Not sorted",
+			"sortedDescending": "Sorted descending",
+			"stick": "Stick",
+			"unlock": "Unlock",
+			"unstick": "Unstick"
+		},
+		"multiselect": {
+			"clearTitle": "Clear value",
+			"noDataText": "No available choice"
+		},
+		"pager": {
+			"firstPage": "Go to the first page",
+			"items": "items",
+			"itemsPerPage": "items per page",
+			"label": "'Page navigation, page {currentPage} of {totalPages}'",
+			"lastPage": "Go to the last page",
+			"nextPage": "Go to the next page",
+			"of": "of",
+			"page": "Page",
+			"pageNumberInputTitle": "Page Number",
+			"previousPage": "Go to the previous page"
+		},
+		"tilelayout": {
+			"component": {
+				"items": "items",
+				"itemsPerPage": "Items per page",
+				"of": "of",
+				"page": "Page"
+			}
+		},
+		"timepicker": {
+			"accept": "Accept",
+			"acceptLabel": "Accept",
+			"cancel": "Cancel",
+			"cancelLabel": "Cancel",
+			"now": "Now",
+			"toggle": "Choose a time"
+		},
+		"upload": {
+			"dropFilesHere": "Drop files here to upload",
+			"invalidMaxFileSize": "File size too large.",
+			"select": "Select files..."
+		}
+	},
+	"models": {
+		"apiConfiguration": {
+			"authType": "Authentication type",
+			"new": "New API Configuration",
+			"selectAuthType": "Select authentication type"
+		},
+		"application": {
+			"description": "Description",
+			"errors": {
+				"style": {
+					"notFound": "Unable to load application's style"
+				}
+			},
+			"id": "Application ID",
+			"new": "New application",
+			"notifications": {
+				"notPublished": "Application not published.",
+				"published": "{{value}} application published.",
+				"updated": "Application updated."
+			},
+			"setAsFavorite": "Set as favorite",
+			"subscription": {
+				"create": "Create a subscription"
+			}
+		},
+		"channel": {
+			"create": "Create a channel",
+			"edit": "Edit channel",
+			"new": "New channel"
+		},
+		"customNotification": {
+			"lastExecution": "Last execution",
+			"schedule": "Schedule",
+			"type": "Notification type"
+		},
+		"dashboard": {
+			"activateFiltering": "Activate filtering",
+			"buttonActions": {
+				"add": "Add button action",
+				"category": "Button category",
+				"confirmDelete": "Are you sure you want to delete this button action?",
+				"edit": "Edit button action",
+				"href": {
+					"title": "Button href",
+					"tooltip": "The href attribute specifies the destination URL when the button is clicked. Can be a relative or absolute URL."
+				},
+				"one": "Button action",
+				"openInNewTab": "Open in new tab",
+				"text": "Button text",
+				"variant": "Button variant"
+			},
+			"closable": "Closable",
+			"context": {
+				"datasource": {
+					"alert": "Select a datasource, in order to set one page per record of the datasource. You can also set a template, which would be loaded by default if no specific page is created for a record.",
+					"info": "Indicate the field that would be use to select records",
+					"set": "Set context datasource",
+					"title": "Context datasource",
+					"update": "Update context datasource"
+				},
+				"displayField": "Display field",
+				"edition": {
+					"element": "You are editing the view for selected element.",
+					"template": "You are editing template of the page. It will be loaded by default if no specific view is created for a record."
+				},
+				"notifications": {
+					"creatingTemplate": "Creating new template",
+					"loadDefault": "Displaying default template",
+					"templateCreated": "New template created"
+				},
+				"origin": "Context origin",
+				"refData": {
+					"element": "Element"
+				},
+				"selectDisplayField": "Select display field",
+				"selectOrigin": "Select context origin",
+				"title": "Context",
+				"tooltip": {
+					"useContextEditor": "Use context editor",
+					"useDefaultEditor": "Use default editor"
+				}
+			},
+			"contextFilter": "Context filter",
+			"dashboardFilter": "Dashboard filter",
+			"deactivateFiltering": "Deactivate filtering",
+			"filterVariant": {
+				"title": "Filter variant",
+				"variantsOptions": {
+					"selectOrigin": "Select filter variant",
+					"variant_default": "Default",
+					"variant_modern": "Modern"
+				}
+			},
+			"historicalDate": "Get dataset at",
+			"share": "Share Dashboard",
+			"tooltip": {
+				"filter": {
+					"closable": "When variant is modern, or application is used as web element, it will indicate if filter can be closed or not",
+					"fields": "You can use fields from the dashboard filter as well as static values to filter the dataset.",
+					"position": "Only applicable when default variant is active"
+				},
+				"historicalDate": "You can use a field from the dashboard filter to query dataset at a specific date.\nIndicate which field to use, by using this syntax: {{filter.<name>}}."
+			}
+		},
+		"form": {
+			"core": "Core",
+			"create": "Create a Form",
+			"edit": "Edit form",
+			"field": {
+				"itemsLabel": "Items label",
+				"label": "Label",
+				"name": "Field name",
+				"usedIn": "Used in"
+			},
+			"new": "New form",
+			"notifications": {
+				"savingFailed": "Saving failed, some fields require your attention."
+			},
+			"select": "Select a Form",
+			"template": "Template"
+		},
+		"group": {
+			"create": "Create a group",
+			"description": "Description",
+			"fetch": "Fetch groups from service",
+			"title": "Title"
+		},
+		"mapping": {
+			"add": "Add a Mapping",
+			"edit": "Edit a Mapping"
+		},
+		"page": {
+			"add": "Add a Page",
+			"tooltip": {
+				"drag": "Drag and drop to reorder",
+				"duplicate": "Select the application you want to put the copy in"
+			}
+		},
+		"positionAttribute": {
+			"edit": "Edit position attribute",
+			"new": "New position attribute"
+		},
+		"pullJob": {
+			"edit": "Edit pull job",
+			"new": "New pull job",
+			"nextIteration": "Next iteration",
+			"path": "Path",
+			"schedule": "Schedule",
+			"url": "Url"
+		},
+		"record": {
+			"convert": "Convert",
+			"edit": "Edit record",
+			"new": "New record",
+			"notifications": {
+				"conversionIncomplete": "Selected record(s) do not match with some fields from this form.",
+				"rowsAdded": "Added {{length}} row(s) to the field {{field}} in the record {{value}}.",
+				"rowsNotAdded": "Error on add row(s).",
+				"uploadSuccessful": "Records upload successful."
+			},
+			"restore": "Restore",
+			"select": "Select a record"
+		},
+		"referenceData": {
+			"add": "Add new reference data",
+			"select": "Select a reference data"
+		},
+		"resource": {
+			"create": "Create a Resource",
+			"select": "Select a Resource"
+		},
+		"role": {
+			"create": "Create a role",
+			"description": "Description",
+			"title": "Title"
+		},
+		"step": {
+			"new": "New step"
+		},
+		"subscription": {
+			"edit": "Edit subscription",
+			"new": "New subscription"
+		},
+		"user": {
+			"firstName": "First name",
+			"lastName": "Last name",
+			"notifications": {
+				"rolesUpdated": "{{username}} roles updated.",
+				"userImportFail": "The user import has failed"
+			},
+			"username": "Username"
+		},
+		"widget": {
+			"add": "Add a Widget",
+			"chart": {
+				"defaultTitle": "Chart Widget"
+			},
+			"delete": {
+				"confirmationMessage": "Do you confirm the deletion of the widget?",
+				"title": "Delete Widget"
+			},
+			"display": {
+				"border": "Show widget border",
+				"expand": "Show button to expand widget",
+				"header": "Show widget header",
+				"padding": "Use widget inner padding",
+				"searchable": "Allow search",
+				"sortable": "Allow sorting",
+				"title": "Widget display",
+				"tooltip": "Show tooltip"
+			},
+			"map": {
+				"defaultTitle": "Map Widget",
+				"latitude": "Latitude",
+				"longitude": "Longitude",
+				"zoom": "Zoom"
+			},
+			"sorting": {
+				"add": "Add a field",
+				"delete": "Delete sort field",
+				"empty": "No sort field set",
+				"field": "Field",
+				"label": "Label",
+				"management": "Sort fields",
+				"order": "Order",
+				"select": "Select a sort field...",
+				"title": "Sorting"
+			},
+			"tooltip": {
+				"expandButton": {
+					"expand": "Expand widget",
+					"help": "Only appears in front-office or in preview mode",
+					"restore": "Restore default"
+				},
+				"selector": {
+					"collapse": "Hide widget selector",
+					"expand": "Show widget selector"
+				}
+			}
+		},
+		"workflow": {
+			"notifications": {
+				"cannotGoToNextStep": "Cannot go to the next step.",
+				"cannotGoToPreviousStep": "Cannot go to the previous step.",
+				"goToStep": "Back to {{step}} step."
+			}
+		}
+	},
+	"pages": {
+		"administration": {
+			"title": "Administration"
+		},
+		"aggregation": {
+			"preview": {
+				"label": "Aggregation data preview",
+				"missingAggregation": "Cannot load selected aggregation. Aggregation not found"
+			}
+		},
+		"apiConfiguration": {
+			"authentication": "Authentication settings",
+			"baseUrl": "Main endpoint",
+			"clientId": "Client ID",
+			"graphQL": {
+				"endpoint": "GraphQL endpoint",
+				"title": "GraphQL Settings"
+			},
+			"host": "Host settings",
+			"notifications": {
+				"authTokenFetched": "Authentication token fetched, ping again to get the actual response.",
+				"pingFailed": "Ping request failed.",
+				"pingReceived": "Received positive response from ping request."
+			},
+			"ping": "Try settings",
+			"pingUrl": "Ping extension",
+			"placeholder": {
+				"baseUrl": "Base URL for the API",
+				"clientId": "Enter client ID",
+				"graphQLEndpoint": "GraphQL extension",
+				"pingUrl": "Enter ping extension URL",
+				"scope": "Enter scope",
+				"secret": "Enter client secret",
+				"token": "Enter token for authentication",
+				"tokenUrl": "Enter access token URL"
+			},
+			"scope": "Scope",
+			"secret": "Client Secret",
+			"token": "Token",
+			"tokenUrl": "Access token URL"
+		},
+		"apiConfigurations": {
+			"create": "Create an API Configuration"
+		},
+		"appBuilder": {
+			"title": "Site builder"
+		},
+		"application": {
+			"addPage": {
+				"form": {
+					"title": "Available forms"
+				},
+				"selectType": "Select which type of page you want to create",
+				"startFromWidget": "Start from a widget"
+			},
+			"empty": {
+				"add": "Add a Page",
+				"create": "Click on create to finish the process",
+				"customize": "Customize each of the pages created"
+			},
+			"positionAttributes": {
+				"create": "Create a position category",
+				"title": "Attributes"
+			},
+			"settings": {
+				"actions": "Actions"
+			}
+		},
+		"applications": {
+			"all": "All applications",
+			"goTo": "Go to Application list",
+			"recent": "Recent applications",
+			"title": "My applications"
+		},
+		"dashboard": {
+			"update": {
+				"exit": "Exit without saving changes",
+				"exitMessage": "There are unsaved changes on the page. Are you sure you want to exit?"
+			}
+		},
+		"formBuilder": {
+			"errors": {
+				"choices": {
+					"valueDuplicated": "Please provide unique values for each of the choices of question: {{question}}"
+				},
+				"dataFieldDuplicated": "Data name duplicated : {{name}}. Please provide different value names for all questions.",
+				"missingName": "Missing value name for an element on page {{page}}. Please provide a valid data value name (snake_case) to save the form.",
+				"multipletext": {
+					"missingName": "Please provide name or title for each text of question: {{question}}"
+				},
+				"selectApplication": "Missing value application for an element on page {{page}}. Please select at least one application in properties of {{question}} to save the form.",
+				"snakecase": "The value name {{name}} on page {{page}} is invalid. Please conform to snake_case."
+			},
+			"move": {
+				"down": "Move down",
+				"up": "Move up"
+			},
+			"questionsCategories": {
+				"core": "Question Library"
+			},
+			"title": "Advanced settings"
+		},
+		"forms": {
+			"title": "Available forms"
+		},
+		"profile": {
+			"notifications": {
+				"notUpdated": "Error on saving preferences.",
+				"updated": "Preferences saved."
+			},
+			"password": {
+				"change": "Change password"
+			},
+			"title": "Your profile"
+		},
+		"pullJobs": {
+			"create": "Create a pull job"
+		},
+		"referenceData": {
+			"csv": "CSV input",
+			"fields": {
+				"fetch": "Fetch fields",
+				"help": "The fields are calculated based on the attributes of the first item in the payload.",
+				"missingConfig": "Can't fetch fields. Missing configuration: {{config}}",
+				"noFields": "No fields found",
+				"title": "Field"
+			},
+			"graphQLFilter": "GraphQL query parameters",
+			"pagination": {
+				"cursorPath": "Cursor path",
+				"cursorVariable": "Cursor query variable",
+				"offsetVariable": "Offset query variable",
+				"pageSizeVariable": "Page size query variable",
+				"pageVariable": "Page number query variable",
+				"strategy": "Pagination strategy",
+				"totalCountPath": "Total items count path",
+				"usePagination": {
+					"hint": "Depends on API support, allows fetching data by page",
+					"text": "Use pagination"
+				}
+			},
+			"path": {
+				"placeholder": "Enter a valid JSONPath",
+				"title": "Data path"
+			},
+			"payload": {
+				"label": "Payload",
+				"show": "Show payload"
+			},
+			"placeholder": {
+				"csv": "Insert CSV here",
+				"graphQLFilter": "Enter a filter to be used once choices are already cached"
+			},
+			"queryName": "Query Name",
+			"tooltip": {
+				"graphQLFilter": "You can use {{lastUpdate}} to dynamically get the last fetch date in SQL format.",
+				"path": "Uses JSONPath syntax to extract items from the JSON response. Examples: $.data[*].name, $.data..countries, $.data.countries.*"
+			},
+			"type": "Type",
+			"validateCsv": "Validate CSV",
+			"valueField": "Value Field"
+		},
+		"workflow": {
+			"addStep": {
+				"selectType": "Select which type of step you want to create"
+			},
+			"deleteStep": {
+				"confirmationMessage": "Are you sure you want to delete {{step}}?\n This action cannot be undone."
+			},
+			"empty": {
+				"add": "Add steps",
+				"customize": "Customize each of the steps created"
+			}
+		}
+	}
 }

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1,2603 +1,2603 @@
 {
-  "common": {
-    "access": "Accès",
-    "accessDenied": "Accès refusé",
-    "account": "Compte",
-    "actions": "Actions",
-    "add": "Ajouter",
-    "adminField": "Champ administrateur",
-    "aggregation": {
-      "add": "Ajouter une agrégation",
-      "few": "Agrégations",
-      "none": "Aucune agrégation",
-      "one": "Agrégation"
-    },
-    "apiConfiguration": {
-      "few": "Configurations d'API",
-      "none": "Aucune configuration d'API",
-      "one": "Configuration d'API"
-    },
-    "application": {
-      "few": "Applications",
-      "none": "Aucune application",
-      "one": "Application"
-    },
-    "archive": {
-      "delete": "Supprimer",
-      "few": "Archives",
-      "modal": {
-        "delete": {
-          "action": "Supprimer",
-          "confirmationMessage": "Voulez-vous supprimer l'archive {{name}}?",
-          "title": "Supprimer?"
-        },
-        "restore": {
-          "action": "Restaurer",
-          "confirmationMessage": "Voulez-vous restaurer {{name}}?",
-          "title": "Restaurer?"
-        }
-      },
-      "none": "Aucun élément archivé",
-      "restore": "Restaurer"
-    },
-    "ariaLabel": {
-      "search": {
-        "clear": "Supprimer la recherche"
-      }
-    },
-    "asc": "Croissant",
-    "attribute": {
-      "few": "Attributs",
-      "none": "Aucun attribut",
-      "one": "Attribut"
-    },
-    "auto": "Automatique",
-    "back": "Retour",
-    "bookmarks": "Marque-pages",
-    "calculatedField": {
-      "few": "Champs dérivés",
-      "none": "Aucun champ dérivé",
-      "one": "Champ dérivé"
-    },
-    "cancel": "Annuler",
-    "channel": {
-      "few": "Canaux de diffusion",
-      "none": "Aucun canal de diffusion",
-      "one": "Canal de diffusion"
-    },
-    "child": {
-      "edit": "Modifier l'enfant",
-      "one": "Enfant"
-    },
-    "clear": "Annuler",
-    "close": "Fermer",
-    "column": {
-      "few": "Colonnes",
-      "none": "Aucune colonne",
-      "one": "Colonne"
-    },
-    "comma": "virgule",
-    "copy": "Copier",
-    "create": "Créer",
-    "createdOn": "Date de création",
-    "cronEditor": {
-      "advanced": "Avancé",
-      "atTime": "À",
-      "daily": "Quotidien",
-      "day": "Jour",
-      "days": "Jour(s)",
-      "every": {
-        "feminine": "Toutes les",
-        "masculine": "Tous les"
-      },
-      "firstWeekDay": "Premier jour de la semaine",
-      "hourly": "Horaire",
-      "hours": "Heure(s)",
-      "lastDay": "Dernier jour",
-      "lastWeekDay": "Dernier jour de la semaine",
-      "minutely": "Chaque minute",
-      "minutes": "Minute(s)",
-      "month": "Mois",
-      "monthly": "Mensuel",
-      "months": {
-        "april": "Avril",
-        "august": "Août",
-        "december": "Décembre",
-        "february": "Février",
-        "january": "Janvier",
-        "july": "Juillet",
-        "june": "Juin",
-        "march": "Mars",
-        "may": "Mai",
-        "november": "Novembre",
-        "october": "Octobre",
-        "september": "Septembre"
-      },
-      "of": "du",
-      "ofEvery": "de chaque",
-      "onThe": {
-        "feminine": "Pendant la",
-        "masculine": "Pendant le"
-      },
-      "seconds": "Seconde(s)",
-      "week": "Semaine",
-      "weekDay": "Jour de la semaine (LUN-VEN)",
-      "weekDays": {
-        "friday": "Vendredi",
-        "monday": "Lundi",
-        "saturday": "Samedi",
-        "sunday": "Dimanche",
-        "thursday": "Jeudi",
-        "tuesday": "Mardi",
-        "wednesday": "Mercredi"
-      },
-      "weekNumber": {
-        "fifth": "Cinquième",
-        "first": "Première",
-        "fourth": "Quatrième",
-        "last": "Dernière",
-        "second": "Deuxième",
-        "third": "Troisième"
-      },
-      "weekly": "Hebdomadaire",
-      "yearly": "Annuel"
-    },
-    "customNotification": {
-      "few": "Notifications",
-      "none": "Aucune notification",
-      "one": "Notification"
-    },
-    "dashboard": {
-      "few": "Tableaux de bord",
-      "none": "Aucun tableau de bord",
-      "one": "Tableau de bord"
-    },
-    "delete": "Supprimer",
-    "deleteObject": "Supprimer {{name}}",
-    "deleted": "Supprimé",
-    "desc": "Décroissant",
-    "dismiss": "Fermer",
-    "display": "Afficher",
-    "distributionList": {
-      "few": "Listes de distribution",
-      "none": "Aucune liste de distribution",
-      "one": "Liste de distribution"
-    },
-    "downloadObject": "Télécharger {{name}}",
-    "downloadTemplate": "Télécharger le modèle",
-    "duplicate": "Dupliquer",
-    "edit": "Modifier",
-    "email": {
-      "few": "Emails",
-      "none": "Pas d'email",
-      "one": "Email"
-    },
-    "errors": {
-      "few": "Erreurs",
-      "objectDuplicated": "{{type}} {{value}} existe déjà."
-    },
-    "exitFullscreen": "Quitter le mode plein écran",
-    "export": "Exporter",
-    "exportObject": "Exporter {{name}}",
-    "false": "Faux",
-    "field": {
-      "few": "Champs",
-      "none": "Aucun champ",
-      "one": "Champ"
-    },
-    "filter": {
-      "apply": "Appliquer",
-      "clear": "Supprimer le filtre",
-      "empty": "Aucun résultat",
-      "few": "Filtres",
-      "hide": "Cacher le filtre",
-      "none": "Pas de filtre",
-      "one": "Filtre",
-      "show": "Afficher le filtre"
-    },
-    "form": {
-      "few": "Formulaires",
-      "none": "Aucun formulaire",
-      "one": "Formulaire"
-    },
-    "general": "Général",
-    "group": {
-      "few": "Groupes",
-      "none": "Pas de groupes",
-      "one": "Groupe"
-    },
-    "hide": "Cacher",
-    "history": "Historique",
-    "id": "Id",
-    "input": {
-      "dateRange": "Intervalle de dates",
-      "none": "-- Aucun --",
-      "rawJson": "JSON brut"
-    },
-    "label": "Etiquette",
-    "layers": {
-      "few": "Couches",
-      "none": "Pas de couche"
-    },
-    "layout": {
-      "few": "Mises en page",
-      "none": "Aucune mise en page",
-      "one": "Mise en page"
-    },
-    "loading": "Chargement",
-    "modifiedOn": "Modifié le ",
-    "name": "Nom",
-    "next": "Suivant",
-    "noOptions": "Aucun choix disponible",
-    "notifications": {
-      "accessDenied": "Vous n'avez pas la permission pour accéder à cet objet de type {{type}}.",
-      "accessNotProvided": "Pas d'accès fourni à cet objet de type {{type}}. {{error}}",
-      "alreadyExists": "Cet objet {{type}} {{value}} existe déjà dans cette application.",
-      "copiedToClipboard": "Lien du tableau de bord copié !",
-      "dataNotRecovered": "Échec de la récupération des données",
-      "dataRecovered": "Les données ont été récupérées !",
-      "email": {
-        "error": "Un problème est survenu lors de l'envoi de l'e-mail",
-        "errors": {
-          "noDistributionList": "Un problème est survenu lors de l'envoi de l'e-mail: aucune liste de distribution détectée",
-          "noTemplate": "Un problème est survenu lors de l'envoi de l'e-mail: aucun template détecté"
-        },
-        "processing": "Envoi en cours...",
-        "ready": "E-mail prêt",
-        "sent": "E-mail envoyé"
-      },
-      "fetchingGroups": "Fetching groups from service...",
-      "file": {
-        "download": {
-          "error": "Un problème est survenu lors du téléchargement",
-          "ongoing": "Votre téléchargement est en cours. Vous recevrez bientôt un e-mail contenant votre fichier.",
-          "processing": "Téléchargement du fichier en cours...",
-          "ready": "Votre fichier est prêt"
-        },
-        "upload": {
-          "error": "Un problème est survenu lors de l'import",
-          "maxFileSize": "La taille maximale du fichier est de {{size}} Mo.",
-          "processing": "Fichier en cours d'importation...",
-          "ready": "Fichier importé"
-        }
-      },
-      "formStatus": "Le statut actuel du formulaire ne permet pas son affichage.",
-      "formatInvalid": "Veuillez importer un fichier de format .{{format}}.",
-      "groups": {
-        "error": "Une erreur s'est produite lors de la tentative d'obtenir des groupes du service",
-        "processing": "Récupération des groupes à partir du service...",
-        "ready": "Groupes récupérés"
-      },
-      "history": {
-        "error": "Un problème est survenu lors de la génération de l'historique. {{error}}"
-      },
-      "loadedFromCache": "Objet de type {{type}} chargé depuis le cache.",
-      "noOpened": "Aucun objet {{value}} n'a été ouvert.",
-      "objectCreated": "{{value}} {{type}} créé avec succès.",
-      "objectDeleted": "{{value}} supprimé avec succès.",
-      "objectDuplicated": "{{type}} {{value}} dupliqué avec succès.",
-      "objectInvited": "{{name}} a été invité.",
-      "objectLocked": "L'édition de {{name}} a été bloquée par un autre utilisateur.",
-      "objectNotCreated": "L'objet de type {{type}} n'a pas pu être créé. {{error}}",
-      "objectNotDeleted": "L'objet {{value}} n'a pas pu être supprimé. {{error}}",
-      "objectNotDuplicated": "L'objet de type {{type}} n'a pas pu être dupliqué. {{error}}",
-      "objectNotFound": "{{name}} n'a pas été trouvé.",
-      "objectNotInvited": "L'invitation vers {{name}} a échoué.",
-      "objectNotReordered": "{{type}} non réorganisé. {{error}}",
-      "objectNotRestored": "{{value}} non restauré. {{error}}",
-      "objectNotUpdated": "L'objet de type {{type}} n'a pas pu être modifié. {{error}}",
-      "objectReordered": "L'objet de type {{type}} a été réorganisé.",
-      "objectRestored": "{{value}} restauré.",
-      "objectUpdated": "{{value}} {{type}} a été modifié.",
-      "platformAccessNotGranted": "Vous n'avez pas d'accès valide à cette plateforme.",
-      "readAll": "Tout marqué comme lu",
-      "statusUpdated": "Statut mis à jour par {{value}}.",
-      "unlocked": "L'édition de l'objet {{name}} a été débloquée par un autre utilisateur."
-    },
-    "openFullScreen": "Ouvrir en plein écran",
-    "options": "Options",
-    "or": "Ou",
-    "page": {
-      "few": "Pages",
-      "none": "Aucune page",
-      "one": "Page"
-    },
-    "pagination": {
-      "empty": "Aucun résultat",
-      "itemsPerPage": "Éléments par page",
-      "loadMore": "Charger plus",
-      "of": "de"
-    },
-    "placeholder": {
-      "address": "Entrez une adresse exemple : 1 rue de la paix, Paris",
-      "email": "Entrez un email",
-      "name": "Entrez un nom",
-      "search": "Rechercher...",
-      "title": "Entrez un titre"
-    },
-    "platform": {
-      "backOffice": "Back-Office"
-    },
-    "position": {
-      "bottomleft": "En bas à gauche",
-      "bottomright": "En bas à droite",
-      "topleft": "En haut à gauche",
-      "topright": "En haut à droite"
-    },
-    "positionAttribute": {
-      "few": "Attributs de position",
-      "none": "Aucun attribut de position",
-      "one": "Attribut de position"
-    },
-    "positionCategory": {
-      "few": "Catégories de position",
-      "none": "Aucune catégorie de position",
-      "one": "Catégories de position"
-    },
-    "preview": "Prévisualisation",
-    "previous": "Précédent",
-    "publish": "Publier",
-    "pullJob": {
-      "few": "Tâches planifiées",
-      "none": "Aucune tâche planifiée",
-      "one": "Tâche planifiée"
-    },
-    "record": {
-      "few": "Enregistrements",
-      "none": "Pas d'enregistrement",
-      "one": "Enregistrement"
-    },
-    "referenceData": {
-      "few": "Références de données",
-      "none": "Aucune référence de données",
-      "one": "Référence de données"
-    },
-    "remove": "Retirer",
-    "resource": {
-      "few": "Ressources",
-      "none": "Aucune ressource",
-      "one": "Ressource"
-    },
-    "role": {
-      "few": "Rôles",
-      "none": "Aucun rôle",
-      "one": "Rôle"
-    },
-    "row": {
-      "few": "Rangées",
-      "none": "Aucune rangée",
-      "one": "Rangée",
-      "update": {
-        "few": {
-          "content": "Souhaitez vous mettre à jour les {{count}} enregistrements?",
-          "title": "Mise à jour des enregistrements"
-        },
-        "one": {
-          "content": "Souhaitez vous mettre à jour l’enregistrement?",
-          "title": "Mise à jour de l’enregistrement"
-        }
-      }
-    },
-    "save": "Sauvegarder",
-    "saveChanges": "Sauvegarder les changements",
-    "search": "Recherche",
-    "searchObject": "Rechercher {{name}}",
-    "select": "Sélectionner",
-    "selectStatus": "Sélectionner un statut",
-    "semicolon": "point-virgule",
-    "send": "Envoyer",
-    "separator": "Séparateur",
-    "settings": "Paramètres",
-    "status": "Statut",
-    "status_active": "Actif",
-    "status_archived": "Archivé",
-    "status_pending": "Inactif",
-    "step": {
-      "few": "Etape",
-      "none": "Aucune étape",
-      "one": "Etape"
-    },
-    "subscription": {
-      "few": "Abonnements",
-      "none": "Aucun abonnement",
-      "one": "Abonnement"
-    },
-    "tabs": "Onglets",
-    "template": {
-      "few": "Modèles de notification",
-      "none": "Aucun modèle",
-      "one": "Modèle de notification"
-    },
-    "title": "Titre",
-    "tooltip": {
-      "dragDrop": "Glissez-déposez pour réorganiser",
-      "editor": {
-        "insert": "Tapez '{' pour utiliser des expressions et des variables"
-      }
-    },
-    "true": "Vrai",
-    "type": {
-      "few": "Types",
-      "none": "Aucun type",
-      "one": "Type"
-    },
-    "update": "Mettre à jour",
-    "updateObject": "Mettre à jour {{name}}",
-    "uploadObject": "Importer {{name}}",
-    "user": {
-      "few": "Utilisateurs",
-      "none": "Aucun utilisateur",
-      "one": "Utilisateur"
-    },
-    "value": {
-      "few": "Valeurs",
-      "none": "Aucune valeur",
-      "one": "Valeur"
-    },
-    "viewFullscreen": "Ouvrir le mode plein écran",
-    "viewObject": "Voir {{name}}",
-    "workflow": {
-      "few": "Workflows",
-      "none": "Aucun workflow",
-      "one": "Workflow"
-    }
-  },
-  "components": {
-    "access": {
-      "canDelete": "Peut supprimer",
-      "canSee": "Peut voir",
-      "canUpdate": "Peut modifier",
-      "description": "Modifier les permissions de {{name}}",
-      "title": "Accès"
-    },
-    "aggregation": {
-      "add": {
-        "choice": {
-          "create": "Créer une nouvelle agrégation",
-          "load": "Charger une agrégation"
-        },
-        "select": "Sélectionner une agrégation",
-        "title": "Ajouter une agrégation"
-      },
-      "edit": {
-        "title": "Paramètres d'agrégation"
-      }
-    },
-    "aggregationBuilder": {
-      "accumulators": "Accumulateurs",
-      "addField": "Ajouter un champ",
-      "addRule": "Ajouter une règle",
-      "addStage": "Ajouter une étape",
-      "dataset": {
-        "select": "Sélectionner la source de données"
-      },
-      "fieldName": "Nom du champ",
-      "groupBy": "Regrouper par",
-      "groupingRules": "Grouper par",
-      "mapping": {
-        "category": "Catégorie",
-        "field": "Valeur",
-        "series": "Séries"
-      },
-      "operator": "Opérateur",
-      "operators": {
-        "add": "Ajouter",
-        "avg": "Moyenne",
-        "count": "Compte",
-        "day": "Jour",
-        "first": "Premier",
-        "last": "Dernier",
-        "max": "Maximum",
-        "min": "Minimum",
-        "month": "Mois",
-        "multiply": "Multiplier",
-        "sum": "Somme",
-        "week": "Semaine",
-        "year": "Année"
-      },
-      "preview": {
-        "hide": "Masquer l'aperçu",
-        "show": "Afficher l'aperçu"
-      },
-      "sourceFields": "Sélectionner les champs",
-      "stages": {
-        "addFields": "Ajouter des champs",
-        "custom": "Personnaliser",
-        "filter": "Filtrer",
-        "group": "Grouper & Accumulateur",
-        "sort": "Trier",
-        "unwind": "Dissocier"
-      },
-      "tooltip": {
-        "addFields": "Ajouter de nouveaux champs au document.",
-        "custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
-        "filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
-        "group": "Regroupe les enregistrements en fonction des valeurs de champ et construit des accumulateurs personnalisés.",
-        "groupingRules": "Les règles de regroupement sont facultatives.",
-        "selectedFields": "Seuls les champs non utilisés peuvent être supprimés.",
-        "sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.\nLa mise en place de des étapes de tri successives triera simultanément tous les champs.",
-        "unwind": "Déconstruit un tableau depuis les documents d'entrée et ressort un document pour chaque élément."
-      }
-    },
-    "apiConfiguration": {
-      "create": {
-        "errors": {
-          "name": "Nom invalide: utilisez seulement des lettres, des chiffres et des tirets bas."
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer la configuration d'API {{name}} ?",
-        "title": "Supprimer la configuration d'API"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page de configurations d'API"
-      }
-    },
-    "application": {
-      "archive": {
-        "autoDeletedAt": "Date de suppression automatique",
-        "name": "Nom"
-      },
-      "customStyling": "Style personnalisé",
-      "dashboard": {
-        "clearFields": "Supprimer les champs",
-        "editFilter": "Modifier le filtre",
-        "empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée.",
-        "enterEditMode": "Entrer en mode édition",
-        "enterPreviewMode": "Entrer en mode prévisualisation",
-        "filter": {
-          "empty": "Aucun filtre n'a été défini par les administrateurs",
-          "filterPosition": {
-            "bottom": "Afficher le filtre en bas",
-            "left": "Afficher le filtre à gauche",
-            "right": "Afficher le filtre à droite",
-            "top": "Afficher le filtre en haut",
-            "unset": "Position indéfinie, sélectionnez en une"
-          },
-          "info": "Les filtres de tableau de bord peuvent être utilisés entre les pages pour filtrer leur contenu.",
-          "title": "Vous modifiez les filtres du tableau de bord"
-        },
-        "filterSettings": "Paramètres du filtre",
-        "settings": {
-          "defaultPosition": "Position par défaut du filtre",
-          "fixedRowHeight": "Hauteur de ligne fixe",
-          "gridOptions": "Options de grille",
-          "gridType": {
-            "fit": "Ajuster",
-            "placeholder": "Sélectionnez un type de grille",
-            "title": "Type de grille",
-            "verticalFixed": "Vertical fixe"
-          },
-          "help": {
-            "minCols": "Réduire le nombre de colonnes peut ne pas avoir un impact direct si les widgets dépassent la limite spécifiée en largeur."
-          },
-          "margin": "Marge entre les widgets",
-          "minCols": "Nombre de colonnes",
-          "minimumHeight": "Hauteur minimum",
-          "tooltip": {
-            "fixedRowHeight": "Taille des lignes en pixels.\nDoit être supérieur ou égal à 50.",
-            "margin": "Marge entre les widgets.\nDoit être un entier positif.",
-            "minCols": "Nombre de colonnes.\nDoit être compris entre 4 et 24.",
-            "minimumHeight": "Taille minimale de la grille en pixels.\nDoit être supérieur ou égal à 0.",
-            "reset": "Réinitialiser la valeur"
-          },
-          "tooltips": {
-            "clear": "Définir les valeurs par défaut",
-            "fixedRowHeight": "Minimum: 50, Par défaut: 200, Pas de max",
-            "margin": "Minimum: 0, Par défaut: 10, Pas de max",
-            "minCols": "Minimum: 4, Par défaut: 8, Maximum: 24"
-          }
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer cette application ?"
-      },
-      "duplicate": {
-        "name": {
-          "description": "Veuillez entrer une description pour cette application."
-        }
-      },
-      "pages": {
-        "delete": {
-          "confirmationMessage": "Voulez-vous vraiment supprimer la page {{name}}?"
-        },
-        "hide": "Cacher la page dans la barre latérale de navigation",
-        "notReordered": {
-          "plural": "Les pages n'ont pas été réorganisées. {{error}}",
-          "singular": "La page n'a pas été réorganisée. {{error}}"
-        },
-        "reordered": {
-          "plural": "Les pages ont été réorganisées avec succès.",
-          "singular": "La page a été réorganisée avec succès."
-        },
-        "settings": {
-          "actions": "Actions",
-          "goNextStepOnSave": "Aller à l'étape suivante après avoir enregistré",
-          "selectIcon": "Sélectionnez une icône",
-          "tooltip": {
-            "autoSave": "Les modifications sont automatiquement enregistrées"
-          }
-        },
-        "show": "Afficher la page dans la barre latérale de navigation"
-      },
-      "positionAttribute": {
-        "delete": {
-          "confirmationMessage": "Voulez-vous vraiment supprimer l'attribut de position {{name}} ?",
-          "title": "Supprimer l'attribut de position"
-        }
-      },
-      "publish": {
-        "confirmationMessage": "Confirmer la publication de l'application {{name}} ?",
-        "title": "Publier l'application"
-      },
-      "subscription": {
-        "modal": {
-          "hint": {
-            "listenTo": "Clé de routage de l'agent de messages"
-          },
-          "listenTo": "Écouter",
-          "placeholder": {
-            "listenTo": "Sélectionner une clé de routage"
-          },
-          "routingKey": {
-            "clear": {
-              "ariaLabel": "Supprimer la clé de routage"
-            }
-          }
-        }
-      },
-      "unlock": {
-        "confirmationMessage": "Voulez-vous déverrouiller l'édition de {{name}} ?",
-        "title": "Déverrouiller l'édition"
-      },
-      "update": {
-        "hideMenu": "Cacher le menu vertical de navigation par défaut",
-        "placeholder": {
-          "description": "Veuillez entrer une description pour l'application."
-        },
-        "sideMenu": "Afficher le menu sur le côté",
-        "tooltip": {
-          "hideMenu": "Ne s'applique que lorsque le menu est sur le côté"
-        }
-      },
-      "users": {
-        "auto": "Attribution automatique",
-        "empty": "Aucun utilisateur détecté",
-        "manual": "Attribution manuelle"
-      }
-    },
-    "applications": {
-      "dropdown": {
-        "select": "Depuis les applications"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page d'applications"
-      }
-    },
-    "calculatedFields": {
-      "add": "Créer un nouveau champ dérivé",
-      "delete": {
-        "confirmationMessage": "Confirmez-vous la suppression du champ dérivé {{name}} ?"
-      },
-      "edit": "Modifier le champ dérivé",
-      "expression": "Expression",
-      "hint": {
-        "name": "Entrez un nom composé uniquement delettres, dechiffres et de tirets bas. Ce nom ne doit pas dupliquer le nom d'un autre champ de la resource éditée."
-      }
-    },
-    "channel": {
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer le canal {{name}} ?"
-      },
-      "dropdown": {
-        "select": "Notifier sur"
-      },
-      "selectChannel": "Sélectionnez un canal"
-    },
-    "confirmModal": {
-      "cancel": "Annuler",
-      "confirm": "Confirmer",
-      "delete": "Supprimer",
-      "title": "Confirmer"
-    },
-    "customNotifications": {
-      "edit": {
-        "dataset": "Jeu de données",
-        "email": "Notification par email",
-        "new": "Nouvelle notification",
-        "recipients": {
-          "distributionList": "Utiliser une liste de distribution",
-          "email": "Utiliser une adresse email unique",
-          "title": "Destinataires",
-          "userField": "Grouper par utilisateurs détectés dans les enregistrements"
-        },
-        "update": "Éditer la notification"
-      },
-      "errors": {
-        "email": "Veuillez entrer une adresse email valide",
-        "schedule": "Veuillez entrer une expression cron valide"
-      },
-      "hint": {
-        "schedule": "Indiquez une fréquence d'envoi"
-      }
-    },
-    "distributionLists": {
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer la liste de distribution: '{{name}}'?"
-      },
-      "edit": {
-        "name": "Nom de la liste de distribution",
-        "new": "Nouvelle liste de distribution",
-        "update": "Éditer la liste de distribution"
-      },
-      "errors": {
-        "emails": {
-          "pattern": "Veuillez uniquement fournir des emails valides",
-          "required": "Veuillez fournir un ou plusieurs emails"
-        },
-        "name": {
-          "required": "Veuillez fournir un nom"
-        }
-      }
-    },
-    "emailBuilder": {
-      "body": "Corps du texte",
-      "default": "Défaut",
-      "fields": "Sélectionner les champs à écrire dans le corps du texte",
-      "from": {
-        "distribution": "Liste de distribution",
-        "field": "Champ de données",
-        "title": "Depuis:"
-      },
-      "subject": "Objet",
-      "withoutRecords": "Sans enregistrements"
-    },
-    "emailPreview": {
-      "errors": {
-        "missingSubject": "L'objet du mail ne peut être vide."
-      },
-      "from": "De",
-      "subject": "Objet",
-      "title": "Prévisualisation de mail",
-      "to": "À"
-    },
-    "floating": {
-      "menuButton": {
-        "ariaLabel": "***"
-      }
-    },
-    "form": {
-      "aggregation": {
-        "delete": {
-          "confirmationMessage": "Confirmez-vous la suppression de l'agrégation {{name}}?"
-        }
-      },
-      "create": {
-        "choice": {
-          "inherit": "Copier un modèle de ressources existant",
-          "resource": "Créer une nouvelle ressource",
-          "template": "Commencer depuis un modèle existant"
-        },
-        "template": {
-          "from": "Depuis le modèle",
-          "placeholder": "Choisir un modèle existant",
-          "selectResource": "Sélectionnez une ressource",
-          "title": "Depuis la ressource"
-        },
-        "tooltip": {
-          "inherit": "Crée un formulaire hérité en utilisant comme modèle la ressource liée à un formulaire source.",
-          "resource": "Crée un formulaire source permettant la création de formulaire hérités liés à celui-ci. Crée aussi une nouvelle ressource liée.",
-          "template": "Si aucun modèle n'est sélectionné, la structure principale sera chargée"
-        }
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer le formulaire {{name}} ?"
-      },
-      "deleteRow": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer {{quantity}} {{rowText}}?"
-      },
-      "display": {
-        "submissionMessage": "Le formulaire a été sauvegardé."
-      },
-      "draftRecords": {
-        "buttonLoad": "Charger un brouillon",
-        "confirmModal": {
-          "confirmDelete": "Voulez-vous vraiment supprimer ce brouillon ?",
-          "confirmLoad": "Voulez-vous vraiment charger ce brouillon ?",
-          "delete": "Supprimer ce brouillon",
-          "load": "Charger ce brouillon"
-        },
-        "creationDate": "Date de création",
-        "delete": "Supprimer ce brouillon",
-        "load": "Charger ce brouillon",
-        "noDrafts": "Aucun enregistrement brouillon disponible",
-        "preview": "Prévisualiser ce brouillon",
-        "previewTitle": "Enregistrement brouillon",
-        "save": "Enregistrer comme brouillon",
-        "select": "Sélectionner le brouillon",
-        "successEdit": "Brouillon modifié avec succès",
-        "successSave": "Enregistré dans les brouillons avec succès"
-      },
-      "layout": {
-        "delete": {
-          "confirmationMessage": "Voulez-vous vraiment supprimer la mise en page {{name}} ?"
-        },
-        "errors": {
-          "invalid": "Le formulaire est invalide"
-        },
-        "update": {
-          "preview": {
-            "description": "Réorganise, trie, filtre et cache des colonnes pour changer l'affichage par défaut de la mise en page"
-          }
-        }
-      },
-      "searchExistingRecords": {
-        "matches": "Résultats",
-        "noMatches": "Aucun résultat",
-        "openRecordTooltip": "Ouvrir l'enregistrement"
-      },
-      "summary": {
-        "cache": {
-          "clear": "Vider le cache",
-          "load": "Charger depuis le cache {{date}}"
-        },
-        "createdBy": "Créé par {{user}} le {{date}}",
-        "modifiedBy": "Modifié pour la dernière fois par {{user}} le {{date}}"
-      },
-      "update": {
-        "exit": "Quitter sans sauvegarder les changements",
-        "exitMessage": "Il y a des changements non sauvegardés dans votre formulaire, voulez-vous vraiment quitter cette page ?"
-      },
-      "updateRow": {
-        "confirmationMessage": "Souhaitez-vous mettre à jour {{quantity}} {{rowText}}?"
-      }
-    },
-    "formBuilder": {
-      "errors": {
-        "duplicatedRelatedName": "Nom lié en double pour la question {{question}} à la page {{page}}. Veuillez fournir un nom lié unique (au format snake_case) pour sauvegarder le formulaire.",
-        "incorrectJSON": "Le JSON est invalide dans le JSON Editor, les changements n'ont pas été sauvegardés",
-        "missingGridField": "Champs disponible de table de données manquant pour la question {{question}} à la page {{page}}. Veuillez en sélectionner au moins un dans la propriété Custom Question pour sauvegarder le formulaire.",
-        "missingRelatedName": "Nom lié manquant pour la question {{question}} à la page {{page}}. Veuillez entrer un nom valide pour la valeur de la donnée (au format snake_case) pour sauvegarder le formulaire.",
-        "missingTemplate": "Ressource liée manquante pour la question {{question}} à la page {{page}}. Veuillez sélectionner un modèle pour sauvegarder le formulaire."
-      },
-      "propertyGrid": {
-        "resource": {
-          "availableGridFields": "Champs de grille disponibles",
-          "resourceSelectText": "Vous devez d’abord sélectionner une ressource avant de définir des filtres"
-        }
-      },
-      "saveSurvey": "Sauvegarde du questionnaire"
-    },
-    "formMapProperties": {
-      "geofields": {
-        "editDialog": {
-          "editGeofield": "Éditer les champs",
-          "label": "Label",
-          "value": "Valeur"
-        }
-      }
-    },
-    "forms": {
-      "isCore": "Est un formulaire source",
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page de formulaires"
-      },
-      "parent": "Formulaire parent"
-    },
-    "group": {
-      "add": {
-        "title": "Ajouter un nouveau groupe"
-      },
-      "delete": {
-        "confirmationMessage": "Confirmez-vous la suppression du groupe {{name}}?",
-        "title": "Supprimer le groupe"
-      }
-    },
-    "header": {
-      "goToApp": "Ouvrir l'application",
-      "goToPlatform": "Naviguer vers",
-      "logout": "Se déconnecter",
-      "sidenav": {
-        "collapse": "Cacher la barre latérale",
-        "show": "Afficher la barre latérale"
-      }
-    },
-    "history": {
-      "changes": {
-        "add": "Ajout",
-        "from": "de",
-        "modify": "Modification",
-        "remove": "Suppression",
-        "to": "à",
-        "withValue": "avec valeur"
-      },
-      "columns": {
-        "action": "Type d'action",
-        "date": "Date",
-        "modifiedValue": "Ancienne valeur",
-        "originalValue": "Nouvelle valeur",
-        "person": "Utilisateur",
-        "time": "Heure",
-        "variable": "Champ"
-      },
-      "download": "Télécharger l'historique",
-      "empty": "Aucune activité détectée",
-      "field": {
-        "all": "Tous les champs",
-        "select": "Sélectionner les champs"
-      },
-      "preview": "Prévisualiser et revenir",
-      "range": {
-        "clear": "Effacer la plage de données"
-      },
-      "useTableMode": "Afficher en table"
-    },
-    "icon": {
-      "modal": {
-        "select": "Sélectionner une icône",
-        "use": "Utiliser l'icône"
-      }
-    },
-    "logout": {
-      "confirmationMessage": "Le formulaire contient des éléments non sauvegardés. Voulez-vous vous vraiment déconnecter ?",
-      "title": "Quitter la plateforme sans sauvegarder"
-    },
-    "map": {
-      "controls": {
-        "download": {
-          "layers": {
-            "all": "Toutes les couches",
-            "selected": "Couches sélectionnées",
-            "visible": "Couches visibles"
-          },
-          "output": "Format d'export",
-          "selectLayers": "Sélectionnez les couches",
-          "view": {
-            "all": "Toute la carte",
-            "current": "Vue actuelle"
-          }
-        },
-        "timeline": {
-          "show": "Afficher la chronologie",
-          "time": {
-            "dateFormat": "Affichage des dates",
-            "startField": "Commencez à afficher à",
-            "stopField": "Arrêter de s'afficher à",
-            "tooltip": "Lorsqu'elle est activée, une chronologie sera affichée sur la carte. Il vous permettra de visualiser l’évolution de vos données dans le temps."
-          },
-          "title": "Timeline"
-        }
-      }
-    },
-    "mapping": {
-      "field": "Champ de l'utilisateur",
-      "path": "Chemin",
-      "text": "Texte",
-      "title": "Table de correspondances",
-      "value": "Valeur"
-    },
-    "notifications": {
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page de notifications"
-      },
-      "readAll": "Tout marquer comme lu",
-      "title": "Notifications"
-    },
-    "paginator": {
-      "items": "élements",
-      "itemsPerPage": "éléments par page",
-      "of": "de",
-      "page": "Page"
-    },
-    "preferences": {
-      "dateFormat": "Format de date et heure",
-      "language": "Langage",
-      "title": "Préférences"
-    },
-    "pullJob": {
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer la tâche {{name}} ?",
-        "title": "Supprimer la tâche"
-      },
-      "modal": {
-        "addMappingField": "ajouter un champ de correspondance",
-        "errors": {
-          "schedule": "Entrez une expression cron valide"
-        },
-        "hint": {
-          "path": "Entrer le chemin pour extraire la donnée de la réponse",
-          "schedule": "Entrez une expression CRON pour planifier la tâche",
-          "url": "Entrez l'URL après l'hôte pour atteindre la donnée spécifique"
-        },
-        "identifier": "Identificateurs uniques",
-        "mapping": "Correspondance",
-        "placeholder": {
-          "path": "Entrez le chemin d'accès...",
-          "schedule": "Entrez l'horaire planifié...",
-          "url": "Entrer l'URL..."
-        },
-        "switch": "Changer de mode"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionez la page de tâches programmées"
-      }
-    },
-    "queryBuilder": {
-      "dataset": {
-        "select": "Sélectionner un jeu de données"
-      },
-      "errors": {
-        "field": {
-          "invalid": "Champ invalide. Veuillez cliquer pour le retirer."
-        }
-      },
-      "fields": {
-        "available": "Champs disponibles",
-        "column": "Largeur de la colonne (px)",
-        "format": {
-          "info": "Laissez vide pour utiliser le mode classique",
-          "title": "Mode d'affichage"
-        },
-        "search": "Rechercher des champs...",
-        "selected": "Champs sélectionnés",
-        "title": "Champs"
-      },
-      "filter": {
-        "and": "Et",
-        "logic": "Logique de filtre",
-        "new": "Ajouter un nouveau filtre",
-        "newGroup": "Ajouter un nouveau groupe de filtres",
-        "operator": "Opérateur",
-        "or": "Ou",
-        "title": "Filtre"
-      },
-      "hint": {
-        "fields": "Sélectionnez des champs ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite",
-        "sortingDisabled": "Le tri est désactivé quand la recherche est active.",
-        "style": "Les règles de style font ressortir les enregistrements contenant des informations importantes. Quand un enregistrement vérifie plusieurs règles, la première est utilisée."
-      },
-      "pagination": {
-        "first": "Limite",
-        "title": "Pagination"
-      },
-      "sort": {
-        "ascending": "Croissant",
-        "descending": "Décroissant",
-        "field": "Filtrer le champ",
-        "limit": "limite",
-        "limitTitle": "Tri et limite",
-        "order": "Ordre de tri",
-        "title": "Tri"
-      },
-      "style": {
-        "and": "Et",
-        "edit": {
-          "appliesTo": "Appliquer le style à",
-          "background": {
-            "color": "Couleur de fond"
-          },
-          "criteria": "Critère",
-          "fields": "Champ",
-          "name": "Nom de la règle",
-          "selectedColumns": "Seulement les colonnes sélectionnées.",
-          "text": {
-            "color": "Couleur du texte",
-            "style": "Style du texte"
-          },
-          "wholeRow": "Ligne entière"
-        },
-        "logic": "Filtre de style",
-        "new": "Ajouter une règle de style",
-        "operator": "Opérateur",
-        "or": "Ou",
-        "title": "Style"
-      },
-      "tooltip": {
-        "filter": {
-          "date": {
-            "useExpression": "Utiliser une expression",
-            "usePicker": "Choisir une date"
-          }
-        },
-        "pagination": {
-          "first": "Limite le nombre d'éléments renvoyés"
-        }
-      }
-    },
-    "record": {
-      "attach": {
-        "confirm": "Attacher",
-        "selectTarget": "Sélectionner la cible {{name}}"
-      },
-      "convert": {
-        "choice": {
-          "copy": "Copier l'enregistrement source",
-          "overwrite": "Écraser l'enregistrement source"
-        },
-        "result": {
-          "force": "Les champs suivants seront ignorés :",
-          "smooth": "Conversion OK"
-        },
-        "select": "Convertir en"
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer l'enregistrement {{name}} ?",
-        "permanently": "Supprimer de manière permanente"
-      },
-      "dropdown": {
-        "select": "Sélectionner un enregistrement"
-      },
-      "history": {
-        "revert": "Revenir à l'enregistrement précédent",
-        "version": {
-          "current": "Version actuelle",
-          "old": "Ancienne version"
-        }
-      },
-      "modal": {
-        "closeConfirmation": "Fermer sans enregistrer les modifications ?",
-        "update": "Sauvegarder et fermer"
-      },
-      "recovery": {
-        "confirmationMessage": "Souhaitez-vous appliquer les données du {{date}} à l'enregistrement ?",
-        "title": "Récupération de données"
-      }
-    },
-    "records": {
-      "active": "Enregistrements actifs",
-      "archived": "Enregistrements archivés",
-      "editAs": "Editer en tant que",
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page d'enregistrements"
-      },
-      "showActive": "Voir les enregistrements actifs",
-      "showArchived": "Voir les enregistrements archivés",
-      "upload": {
-        "hint": "Le fichier doit contenir uniquement un enregistrement par ligne. La ligne d'en-tête contient les noms des champs de données."
-      }
-    },
-    "referenceData": {
-      "create": {
-        "title": "Nouvelle référence de données"
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer la référence de données {{name}} ?",
-        "title": "Supprimer la référence de données"
-      },
-      "dropdown": {
-        "select": "Depuis la référence de données"
-      },
-      "fields": {
-        "add": "Ajouter le champ",
-        "ariaLabel": "Indiquez les champs de la référence de données",
-        "new": "Nouveau champ"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page de références de données"
-      }
-    },
-    "resource": {
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer la ressource {{name}} ?"
-      },
-      "dropdown": {
-        "select": "Depuis la ressource"
-      },
-      "empty": {
-        "aggregations": "Aucune agrégation détectée",
-        "calculatedFields": "Aucun champ dérivé détecté",
-        "layouts": "Aucune mise en page détectée",
-        "records": "Aucun enregistrement détecté"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page de ressources"
-      }
-    },
-    "role": {
-      "add": {
-        "title": "Ajouter un nouveau rôle"
-      },
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer le rôle {{name}} ?",
-        "title": "Supprimer le rôle"
-      },
-      "impersonate": {
-        "title": "Choix du rôle à simuler"
-      },
-      "summary": {
-        "addFilter": "Ajouter un filtre",
-        "autoAssignment": {
-          "rule": {
-            "add": "Ajouter une règle d'attribution",
-            "delete": "Supprimer la règle",
-            "edit": "Mettre à jour la règle d'attribution",
-            "none": "Aucune règle d'attribution automatique",
-            "title": "Règle"
-          },
-          "title": "Attribution automatique"
-        },
-        "details": {
-          "access": {
-            "channels": "Canaux accessibles",
-            "fullAccess": "Accès complet à {{accessible}} / {{total}}",
-            "limitedAccess": "Accès limité à {{accessible}} / {{total}}",
-            "noAccess": "Pas d'accès à {{accessible}} / {{total}}",
-            "pages": "Pages accessibles",
-            "resources": "Ressources accessibles",
-            "title": "Accès"
-          }
-        },
-        "editFilters": "Modifier les filtres",
-        "features": "Fonctionnalités",
-        "newFilter": "Nouveau filtre",
-        "noFeatures": "Aucune fonctionnalité détectée",
-        "noFilters": "Aucun filtre d'accès détecté",
-        "noForms": "Aucun formulaire détecté",
-        "noSteps": "Aucune étape détectée",
-        "removeFilter": "Supprimer le filtre",
-        "title": "Résumé",
-        "users": {
-          "auto": "Attribution automatique",
-          "empty": "Aucun utilisateur détecté",
-          "manual": "Attribution manuelle"
-        }
-      },
-      "tooltip": {
-        "allowFieldAccessibility": "Autoriser ce rôle à voir le champ {{field}}",
-        "allowFieldUpdate": "Autoriser ce rôle à mettre à jour le champ {{field}}",
-        "disallowFieldAccessibility": "Interdire ce rôle pour voir le champ {{field}}",
-        "disallowFieldUpdate": "Interdire ce rôle pour mettre à jour le champ {{field}}",
-        "grantAddRecordsPermission": "Permet de créer de nouveaux enregistrements",
-        "grantDeleteRecordsPermission": "Permet de supprimer tous les enregistrements",
-        "grantFilterDeleteRecordsPermission": "Permet de supprimer les enregistremetns satisfaisant le filtre",
-        "grantFilterReadRecordsPermission": "Permet de voir les enregistrements satisfaisant le filtre",
-        "grantFilterUpdateRecordsPermission": "Permet de mettre à jour les enregistrements satisfaisant le filtre",
-        "grantReadRecordsPermission": "Permet de voir tous les enregistrements",
-        "grantUpdateRecordsPermission": "Permet de mettre à jour tous les enregistrements",
-        "hideFeature": "Masquer {{page}} pour ce rôle",
-        "limitedDeleteRecordsPermission": "Permet de supprimer les enregistrements satisfaisant les filtres",
-        "limitedReadRecordsPermission": "Permet de voir les enregistrements satisfaisant les filtres",
-        "limitedUpdateRecordsPermission": "Permet de mettre à jour les enregistrements satisfaisant les filtres",
-        "notGrantAddRecordsPermission": "Ne donne pas la permission d'ajouter de nouveaux enregistrements",
-        "notGrantDeleteRecordsPermission": "Ne donne pas la permission de supprimer les enregistrements",
-        "notGrantFilterDeleteRecordsPermission": "Ne donne pas la permission de supprimer les enregistrements satisfaisant le filtre",
-        "notGrantFilterReadRecordsPermission": "Ne donne pas la permission de voir les enregistrements satisfaisant le filtre",
-        "notGrantFilterUpdateRecordsPermission": "Ne donne pas la permission de mettre à jour les enregistrements satisfaisant le filtre",
-        "notGrantReadRecordsPermission": "Ne donne pas la permission de voir les enregistrements",
-        "notGrantUpdateRecordsPermission": "Ne donne pas la permission de mettre à jour les enregistrements",
-        "showFeature": "Afficher {{page}} pour ce rôle"
-      },
-      "update": {
-        "permissions": "Permissions",
-        "title": "Modifier les permissions des rôles et les canaux de diffusion"
-      }
-    },
-    "share": {
-      "modal": {
-        "copy": "Copier dans le presse-papiers",
-        "title": "Partager l'url du dashboard"
-      }
-    },
-    "templates": {
-      "available": "Modèles d'email disponibles",
-      "delete": {
-        "confirmationMessage": "Voulez-vous supprimer le modèle '{{name}}'?",
-        "titleMessage": "Supprimer le modèle"
-      },
-      "edit": {
-        "body": "Corps du texte",
-        "name": "Nom du modèle de notification",
-        "new": "Nouveau modèle de notification",
-        "subject": "Sujet",
-        "update": "Éditer le modèle de notification"
-      },
-      "errors": {
-        "empty": "Veuillez sélectionner au moins un modèle"
-      },
-      "select": {
-        "email": "Sélectionnez un modèle d'e-mail"
-      },
-      "type": {
-        "email": "E-mail",
-        "title": "Type de modèle"
-      }
-    },
-    "user": {
-      "delete": {
-        "confirmationMessage": "Voulez-vous vraiment supprimer l'utilisateur {{name}} ?",
-        "title": "Supprimer l'utilisateur"
-      },
-      "invite": {
-        "confirm": "Inviter",
-        "role": {
-          "additionalAttributes": "Définir des attributs supplémentaires",
-          "description": "Sélectionner le rôle à assigner"
-        }
-      },
-      "summary": {
-        "country": "Pays",
-        "firstName": "Prénom",
-        "lastName": "Nom",
-        "locationType": "Type de localisation",
-        "region": "Région",
-        "roles": {
-          "application": "Rôles d'application",
-          "backoffice": "Rôles de back-office",
-          "selectedApplication": "Application sélectionnée",
-          "selectedGroups": "Groupes sélectionnés",
-          "selectedRoles": "Rôles sélectionnés"
-        },
-        "title": "Résumé"
-      },
-      "update": {
-        "title": "Modifier l'utilisateur"
-      }
-    },
-    "users": {
-      "invite": {
-        "add": "Ajouter un nouvel utilisateur",
-        "confirm": "Inviter des utilisateurs",
-        "description": "Sélectionner des utilisateurs existants, inviter de nouveaux utilisateurs ou en importer depuis un fichier Excel"
-      },
-      "onDelete": {
-        "plural": "Les utilisateurs ont été correctement supprimés.",
-        "singular": "L'utilisateur a été correctement supprimé."
-      },
-      "onInvite": {
-        "plural": "Les utilisateurs ont été invités.",
-        "singular": "L'utilisateur a été invité."
-      },
-      "onNotDelete": {
-        "plural": "Les utilisateurs n'ont pas été supprimés. {{error}}",
-        "singular": "L'utilisateur a été supprimé. {{error}}"
-      },
-      "onNotInvite": {
-        "plural": "Les utilisateurs n'ont pas été invités. {{error}}",
-        "singular": "L'utilisateur n'a pas été invité. {{error}}"
-      },
-      "paginator": {
-        "ariaLabel": "Sélectionnez la page d'utilisateurs"
-      }
-    },
-    "widget": {
-      "chart": {
-        "errors": {
-          "aggregation": {
-            "invalid": "Agrégation invalide"
-          }
-        },
-        "filters": {
-          "select": "Sélectionnez un filtre..."
-        },
-        "other": "Autre"
-      },
-      "display": {
-        "tooltip": {
-          "placeholder": "Entrez une valeur pour l'info-bulle"
-        }
-      },
-      "expand": "Étendre",
-      "grid": {
-        "actions": {
-          "detail": "Ouvrir le détail",
-          "downloadReport": "Télécharger",
-          "goTo": "Aller à la page",
-          "history": "Voir l'historique"
-        },
-        "empty": "Aucun enregistrement détecté pour cette configuration de réseau",
-        "errors": {
-          "autoSaveFailed": "L'exécution de l'action a été stoppé à cause d'enregistrement(s) non valide(s). Veuillez les vérifier avant de lancer une autre action.",
-          "invalid": {
-            "backoffice": "Configuration de grille invalide",
-            "frontoffice": "Configuration de grille non valide, veuillez contacter votre administrateur",
-            "widgets": "Configuration de grille non valide, veuillez contacter votre administrateur"
-          },
-          "metaQueryBuildFailed": "Erreur lors de la création des métadonnées",
-          "metaQueryFetchFailed": "Erreur lors de la récupération des métadonnées: {{error}}",
-          "missingDataset": "Sélectionner un jeu de données dans les jeux de données",
-          "noRowsSelected": "Aucune ligne sélectionnée",
-          "queryBuildFailed": "Erreur lors de la création de la requête",
-          "queryFetchFailed": "Erreur lors de la récupération des données : {{error}}",
-          "validationFailed": "Les enregistrements suivants n'ont pas pu être sauvegardés car invalides :\n{{errors}}\nMerci de les modifier en utilisant le bouton \"Mettre à jour \" pour plus de détails."
-        },
-        "export": {
-          "columns": {
-            "choice": {
-              "all": "Toutes les colonnes disponibles",
-              "visible": "Toutes les colonnes visibles"
-            },
-            "title": "Sélectionner les colonnes à exporter"
-          },
-          "dataset": {
-            "choice": {
-              "all": "Tous les enregistrements visibles",
-              "selected": "Seulement les enregistrements visibles"
-            },
-            "title": "Sélectionner les enregistrements à exporter"
-          },
-          "email": {
-            "title": "M'envoyer le fichier par e-mail",
-            "tooltip": "Si sélectionné, vous recevrez le fichier par e-mail, au lieu d'attendre son téléchargement ici."
-          },
-          "format": {
-            "title": "Sélectionner le format d'export"
-          }
-        },
-        "filter": {
-          "toggle": "Activer la visibilité du filtre"
-        },
-        "item": {
-          "few": "{{count}} éléments",
-          "none": "Aucun élément",
-          "one": "{{count}} élément"
-        },
-        "layout": {
-          "button": {
-            "title": "Cela effacera la mise en page actuelle avec la mise en page par défaut"
-          },
-          "reset": "Réinitialiser la mise en page par défaut"
-        },
-        "loading": {
-          "records": "Chargement des enregistrements...",
-          "settings": "Chargement des paramètres..."
-        },
-        "map": {
-          "mapDetailsTitle": "Cartographie des données",
-          "mapDetailsTooltip": "Centré par defaut sur l'enregistrement sélectionné"
-        },
-        "openSettings": "Ouvrir les paramètres",
-        "tooltip": {
-          "displayMap": "Afficher la carte",
-          "openPage": "Aller à la page",
-          "saved": "Changements sauvegardés",
-          "unsaved": "Cliquez sur sauvegarder pour enregistrer les changements",
-          "uploadFailed": "L'enregistrement a échoué. Cliquez pour obtenir plus de détails"
-        },
-        "validation": {
-          "help": "Veuillez modifier l'enregistrement à l'aide du bouton \"Mettre à jour\".",
-          "questionTitle": "Erreurs sur le champ {{question}}:",
-          "subtitle": "Ces erreurs furent détectées durant l'enregistrement :",
-          "title": "L'enregistrement du document {{record}} a échoué"
-        }
-      },
-      "settings": {
-        "chart": {
-          "auto": "auto",
-          "axes": "Axes",
-          "categories": "Catégories",
-          "color": "Couleur",
-          "filters": {
-            "add": "Ajouter un filtre",
-            "delete": "Supprimer le filtre",
-            "empty": "Aucun filtre configuré",
-            "title": "Filtres prédéfinis"
-          },
-          "grid": {
-            "buttons": {
-              "modifySelectedRows": {
-                "confirmation": "Voulez-vous vraiment modifier les lignes sélectionnées?"
-              }
-            },
-            "title": "Grille",
-            "x": {
-              "display": "Afficher les lignes horizontales"
-            },
-            "y": {
-              "display": "Afficher les lignes verticales"
-            }
-          },
-          "hideLegend": "Masquer la légende",
-          "labels": {
-            "percentage": "Pourcentage",
-            "showCategory": "Afficher la catégorie",
-            "showValue": "Afficher la valeur",
-            "title": "Labels",
-            "valueType": "Type de valeur"
-          },
-          "legend": "Légende",
-          "orientation": "Orientation",
-          "other": "Autre",
-          "palette": {
-            "enable": "Configurer la palette",
-            "title": "Palette de couleurs"
-          },
-          "position": "Position",
-          "series": {
-            "fill": "Remplissage",
-            "interpolation": {
-              "step": "Étape d'interpolation",
-              "title": "Interpolation"
-            },
-            "showSeries": "Afficher la serie",
-            "stack": {
-              "enable": "Empiler les séries",
-              "usePercentage": "Utiliser des pourcentages"
-            },
-            "title": "Séries"
-          },
-          "size": "Taille",
-          "stepSize": "Intervalle entre les marques",
-          "style": "Style",
-          "text": "Texte",
-          "title": {
-            "color": "Couleur",
-            "format": "Format"
-          },
-          "tooltip": {
-            "palette": "Les couleurs de la palette sont appliquées par défaut aux éléments du graphqiue, mais peuvent être manuellement changées pour chaque série et catégorie.",
-            "stepSize": "Intervalle entre chaque marque de graduation sur l'axe, lorsque possible"
-          },
-          "type": "Graphique",
-          "xAxis": "Axe X",
-          "yAxis": "Axe Y"
-        },
-        "close": {
-          "confirmationMessage": "Vos changements vont être perdus si vous fermez la fenêtre d'édition. Voulez-vous continuer ?"
-        },
-        "editor": {
-          "recordSelection": "Sélection d'enregistrement",
-          "title": "Éditeur"
-        },
-        "grid": {
-          "actions": {
-            "add": "Ajouter de nouveaux enregistrements",
-            "convert": "Convertir des enregistrements",
-            "delete": "Supprimer les enregistrements",
-            "export": "Exporter les enregistrements",
-            "goTo": {
-              "column": {
-                "label": "Nom de la colonne",
-                "placeholder": "Entrez un nom pour la colonne..."
-              },
-              "field": {
-                "label": "Passer le champ comme paramètre de requête",
-                "placeholder": "Sélectionnez un champ"
-              },
-              "label": "Accédez à la page",
-              "target": {
-                "label": "Naviguez vers la page",
-                "placeholder": "Sélectionnez une page"
-              }
-            },
-            "inline": "Modifier par ligne",
-            "navigateToPage": "Accédez à la page",
-            "pageUrl": {
-              "label": "Url de la source de la page",
-              "placeholder": "Entrez l'id de la page"
-            },
-            "pageUrlTitle": {
-              "label": "Nom de la colonne",
-              "placeholder": "Entrez un nom pour la colonne..."
-            },
-            "remove": "Retirer",
-            "show": "Voir l'historique",
-            "showDetails": "Afficher les détails des enregistrements",
-            "title": "Actions activées",
-            "update": "Modifier les enregistrements",
-            "useRecordId": "Injecter l'identifiant comme paramètre de navigation"
-          },
-          "aggregations": {
-            "add": {
-              "choice": {
-                "create": "Créer une nouvelle agrégation"
-              }
-            },
-            "title": "Aggrégations"
-          },
-          "buttons": {
-            "callback": {
-              "attach": "Attacher à l'enregistrement",
-              "displayField": "Afficher le champ",
-              "export": "Exporter le jeu de données sélectionné",
-              "modify": "Modifier automatiquement les lignes sélectionnées",
-              "modifyField": "Champ à modifier",
-              "modifyValue": "Value to attribute",
-              "notify": {
-                "message": "Message de notification"
-              },
-              "prefill": "Préremplir le formulaire avec les données sélectionnées",
-              "save": "Sauvegarder automatiquement",
-              "selectAllRecords": "Sélectionner tous les enregistrements",
-              "selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
-              "selectDisplay": "Sélectionner les champs affichés",
-              "sendMail": "Envoyer le mail",
-              "workflow": {
-                "close": "Fermer le workflow",
-                "confirm": "Message de confirmation",
-                "next": "Aller à l'étape suivante",
-                "previous": "Aller à l'étape précédente"
-              }
-            },
-            "create": "Ajouter un bouton",
-            "defaultName": "Bouton d'action",
-            "enable": "Activer",
-            "placeholder": {
-              "modifyValue": "Supprimer la valeur"
-            },
-            "requireConfirmation": "Exiger une confirmation",
-            "title": "Bouton d'action rapide",
-            "tooltip": {
-              "attach": "Si activé, vous devez fournir un formulaire et un champ dans ce formulaire. Toutes les lignes sélectionnées seront attachées à un enregistrement de ce formulaire. L'utilisateur pourra choisir cet enregistrement grâce au champ donné.",
-              "mail": {
-                "selectDistributionList": "Sélectionnez la liste de distribution qui fournira les destinataires de l'email",
-                "selectTemplates": "Sélectionnez les modèles d'email que les utilisateurs pourront choisir en utilisant l'action"
-              },
-              "notify": "Si activé, vous devez fournir un canal de diffusion et un message.Toutes les lignes sélectionnées seront envoyées en tant que notification unique sur le canal spécifié. Le message fourni est utilisé pour définir l'action de la notification.",
-              "publish": "Si activé, vous devez fournir un canal de diffusion. Toutes les lignes sélectionnées seront envoyées en tant que notification unique sur le canal spécifié. Quiconque écoutant sur ce canal pourra recevoir ces enregistrements."
-            }
-          },
-          "display": {
-            "actionsTitle": "Afficher le titre des actions",
-            "injectClasses": {
-              "title": "Injecter des valeurs en tant que classes CSS",
-              "tooltip": "Lorsqu'un champ est sélectionné, sa valeur sera ajoutée à l'élément <tr> en tant que classe, lui permettant d'être ciblé par un style personnalisé"
-            },
-            "showSingleActionAsButton": "Afficher une seule action sous forme de bouton"
-          },
-          "hint": {
-            "actions": {
-              "add": "L'utilisateur peut ajouter de nouveaux enregistrements avec le modèle choisi, s'il en a la permission",
-              "convert": "L'utilisateur peut convertir les enregistrements avec les autres modèles de la ressource sélectionnée, s'il en a la permission",
-              "delete": "L'utilisateur peut supprimer les enregistrements affichés, s'il en a la permission",
-              "export": "L'utilisateur peut exporter les enregistrements affichés",
-              "goTo": "L'utilisateur peut accéder au tableau de bord d'enregistrement",
-              "inline": "L'utilisateur peut éditer dans la grille les enregistrements affichés, s'il en a la permission",
-              "navigateToPage": "L'utilisateur peut accéder au tableau de bord d'enregistrement",
-              "show": "L'utilisateur peut afficher l'historique complet des enregistrements affichés",
-              "showDetails": "L'utilisateur peut afficher les informations des enregistrements affichés",
-              "update": "L'utilisateur peut mettre à jour les enregistrements affichés"
-            },
-            "attachToRecord": "Si les enregistrements sélectionnés ne sont joints à aucun enregistrement, l'action sera annulée",
-            "buttons": "Les boutons d'action rapides apparaîtront dans le widget et vous permettront de réaliser chacune des actions ci-dessous",
-            "executionOrder": "Les actions seront exécutées dans l'ordre affiché",
-            "prefillForm": "Si aucun enregistrement n'est créé à cette étape, l'action sera annulée"
-          },
-          "layouts": {
-            "add": {
-              "choice": {
-                "create": "Créer une nouvelle mise en page",
-                "load": "Charger une mise en page existante"
-              },
-              "title": "Ajouter une nouvelle mise en page"
-            },
-            "edit": {
-              "title": "Configuration de la mise en page"
-            },
-            "select": "Sélectionner une mise en page",
-            "title": "Mise en page de la grille"
-          },
-          "tooltip": {
-            "template": "Sélectionnez un modèle à utiliser pour l'ajout et l'édition des enregistrements",
-            "useRecordId": "L'url de redirection contiendra l'identifiant de l'élément, afin de naviguer à une page contextuelle, si configurée"
-          },
-          "warnings": {
-            "add": "Veuillez sélectionner un modèle",
-            "general": "Attention: les actions contiennent des erreurs"
-          }
-        },
-        "iconPicker": {
-          "default": "Standard",
-          "placeholder": "Chezchez un symbole"
-        },
-        "map": {
-          "basemap": "Fond de carte",
-          "category": "Catégories rapides",
-          "dataset": "Sélection du jeu de données",
-          "edit": {
-            "aggregation": "Agrégation",
-            "cluster": {
-              "autoSizeCluster": "Taille automatique des clusters",
-              "cluster": "Cluster",
-              "clusterSettings": "Paramètres de groupes",
-              "clustering": "Clustering",
-              "fields": "Champs de groupes",
-              "font": "Police",
-              "fontSize": "Taille de la police",
-              "high": "Haut",
-              "label": "Libellé du groupes",
-              "lightMode": "Mode lumineux",
-              "low": "Faible",
-              "max": "Max",
-              "min": "Min",
-              "overrideSymbol": "Remplacer le symbole de groupes",
-              "popups": "Groupes pop-ups",
-              "radius": "Rayon de groupes",
-              "sizeRange": "Gamme de taille",
-              "symbol": "Style de symboles"
-            },
-            "datasource": {
-              "origin": "Origine"
-            },
-            "fields": "Champs",
-            "filter": "Filtre",
-            "groupLayers": "Regrouper les calques",
-            "labels": "Étiquettes",
-            "layerDatasource": "Source de données de la couche",
-            "layerEdition": "Edition de couche",
-            "layerProperties": "Propriétés",
-            "layerStyling": "Styles",
-            "popup": "Popup",
-            "properties": {
-              "defaultVisibility": "Visible par défaut",
-              "from": "de zoom ",
-              "opacity": "Opacité",
-              "to": " à zoom",
-              "visibilityRange": "Plage de visibilité",
-              "zoom": "Zoom"
-            },
-            "reduction": {
-              "noReduction": "Pas de réduction",
-              "reduction": "Réduction"
-            },
-            "style": {
-              "color": "Couleur",
-              "fieldForSize": "Taille basée sur le champ",
-              "icon": "Symbole",
-              "size": "Taille",
-              "stylingType": "Style de {{layerType}}"
-            },
-            "styling": {
-              "heatmapOptions": {
-                "blur": "Flou",
-                "gradient": "Gradient",
-                "minOpacity": "Opacité minimum",
-                "radius": "Rayon"
-              }
-            }
-          },
-          "errors": {
-            "latitude": "Latitude incorrecte, merci de sélectionner un nombre entre -90 et 90",
-            "longitude": "Longitude incorrecte, merci de sélectionner un nombre entre -180 et 180"
-          },
-          "geospatial": {
-            "layersStyles": {
-              "fill": {
-                "color": "Couleur du remplissage",
-                "opacity": "Opacité du remplissage",
-                "title": "Remplissage"
-              },
-              "marker": {
-                "color": "Couleur du marqueur",
-                "opacity": "Opacité du marqueur",
-                "title": "Marqueur"
-              },
-              "outline": {
-                "color": "Couleur du contour",
-                "opacity": "Opacité du contour",
-                "title": "Contour",
-                "width": "Largeur du contour"
-              },
-              "title": "Styles de calque"
-            }
-          },
-          "layers": {
-            "add": "Ajouter un nouveau calque",
-            "chooseLayer": "Choisir un calque existant",
-            "createGroup": "Créer un nouveau groupe de couches",
-            "createLayer": "Créer un nouveau calque",
-            "dataSource": {
-              "fieldMapping": "Mapping des Champs",
-              "geoField": "GeoField",
-              "latitude": "Latitude",
-              "longitude": "Longitude"
-            },
-            "edit": "Mettre à jour le calque {{name}}",
-            "online": {
-              "info": "Charger des couches depuis arcGIS online",
-              "select": "Chercher des couches",
-              "selected": "Couches sélectionnées",
-              "title": "Couches en ligne"
-            },
-            "point": {
-              "addNew": "Ajouter une nouvelle règle",
-              "category": "Couches rapides",
-              "color": "Couleur",
-              "info": "Afficher des marqueurs sur la carte pour chaque enregistrement, en indiquant les champs de géolocation de la source de données",
-              "rules": "Règles de marquarge",
-              "rulesInfo": "Configurer la taille et la couleur des marqueurs",
-              "size": "Taille",
-              "title": "Marqueurs"
-            },
-            "popup": {
-              "addField": "Ajouter un champ",
-              "description": "Description",
-              "fields": "Champs",
-              "fieldsElements": {
-                "description": "Description",
-                "title": "Titre"
-              },
-              "popup": "Popup",
-              "popupElements": "Éléments de popup",
-              "text": "Texte",
-              "title": "Titre",
-              "tooltip": {
-                "text": "Tapez '{' pour utiliser les champs de la source de données"
-              }
-            },
-            "remove": "Supprimer le calque",
-            "selectLayer": "Sélectionner un calque",
-            "styling": {
-              "style": "Style"
-            },
-            "types": {
-              "cluster": "Groupes",
-              "heatmap": "Carte de chaleur",
-              "point": "Point",
-              "polygon": "Polygone"
-            }
-          },
-          "legend": {
-            "high": "Haut",
-            "low": "Faible",
-            "title": "Légende"
-          },
-          "popup": {
-            "label": "Champs affichés dans le popup",
-            "location": "Emplacement",
-            "of": "{{current}} sur {{total}}",
-            "zoomTo": "Zoomer sur"
-          },
-          "properties": {
-            "basemap": "Fond de carte",
-            "controls": {
-              "download": "Télécharger",
-              "lastUpdate": "Dernière mise à jour le",
-              "lastUpdateError": "L'heure de la dernière modification n'a pas pu être chargée",
-              "lastUpdatePosition": "Choisissez une position pour afficher l'élément",
-              "layer": "Couches",
-              "legend": "Légende",
-              "measure": "Mesure",
-              "search": "Recherche",
-              "timedimension": "Dimension temporelle",
-              "title": "Contrôles de la carte"
-            },
-            "geographicExtent": "Type d'étendue",
-            "geographicExtentValue": "Valeur de l'étendue",
-            "latitude": "Latitude du centre de la carte",
-            "longitude": "Longitude du centre de la carte",
-            "setByMap": "Utiliser la vue actuelle",
-            "title": "Affichage par défaut",
-            "webmap": "WebMap",
-            "zoom": "Zoom par défaut"
-          },
-          "renderer": {
-            "default": "Défaut",
-            "defaultLabel": "Libellé par défaut",
-            "label": "Libellé",
-            "symbol": "Symbole",
-            "uniqueValue": "Valeurs uniques",
-            "value": "Valeur"
-          },
-          "tooltip": {
-            "category": "Sélectionnez un champ pour séparer vos enregistrements en différentes catégories",
-            "cluster": {
-              "autoSize": "La taille des clusters est automatique si activé, sinon, vous pouvez la définir.",
-              "lightMode": "Le texte s'affichera en blanc si activé, sinon en noir."
-            },
-            "dataset": "Sélectionnez des champs ci-dessous et déplacez-les vers 'champs sélectionnés' sur la droite. Ils seront présents dans le pop-up affiché en cliquant sur les marqueurs",
-            "default": {
-              "latitude": "Définissez la latitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la latitude de la carte d'aperçu.",
-              "longitude": "Définissez la longitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la longitude de la carte d'aperçu.",
-              "zoom": "Sélectionnez un zoom par défaut"
-            },
-            "geographicExtent": "Vous pouvez entrer une valeur statique, ou utiliser les notations {{context}} ou {{filter}} pour injecter la valeur"
-          }
-        },
-        "style": {
-          "customStyling": "Style personnalisé"
-        },
-        "summaryCard": {
-          "add": "Ajouter un carte",
-          "card": {
-            "dataSource": {
-              "layoutStyles": {
-                "queryFilters": {
-                  "help": "N'oubliez pas de supprimer les variables non utilisées.",
-                  "noVariables": "Aucune variable définie",
-                  "refresh": "Afficher toutes les variables graphQL",
-                  "title": "Mappage de variables GraphQL",
-                  "tooltip": "Définissez les valeurs des variables GraphQL définies dans la requête de données de référence. Vous pouvez obtenir les valeurs des filtres à l'aide des modèles {{filter.<question-name>}}. Par exemple : { \"region\": {{filter.region}} }"
-                },
-                "title": "Styles de mise en page",
-                "use": "Utiliser les styles de mise en page",
-                "wholeRow": {
-                  "option1": "Appliquer à tous les champs",
-                  "option2": "Appliquer sur toute la carte",
-                  "title": "Styles de lignes entières :"
-                }
-              },
-              "title": "Source de données"
-            },
-            "display": {
-              "dataSource": "Afficher le lien vers la source de données",
-              "header": "Titre",
-              "padding": "Utiliser la marge intérieure",
-              "title": "Affichage de la carte",
-              "tooltip": {
-                "datasource": "Ajoute un bouton pour afficher la source de données de la carte"
-              }
-            },
-            "gridActions": {
-              "title": "Actions de grille",
-              "tooltip": "Actions de grille activées"
-            },
-            "preview": {
-              "title": "Prévisualisation"
-            },
-            "textEditor": {
-              "alert": "Vous pouvez ajouter des variables ex: {{data.variable}} et faire des calculs ex: {{calc.round( value ; precision )}}",
-              "title": "Éditeur de texte"
-            },
-            "title": "Paramètres de carte",
-            "valueSelector": {
-              "title": "Selection de valeur"
-            }
-          },
-          "create": {
-            "choice": {
-              "blank": "Créer une nouvelle carte",
-              "template": "Utiliser un modèle"
-            }
-          },
-          "dynamic": "Dynamique",
-          "exportable": "Autoriser l'export des cartes",
-          "gridMode": "Peut être affiché en grille",
-          "hint": {
-            "dynamic": "Les cartes dynamiques adaptent leur affichage en fonction du nombre d'éléments dans la source de données. Vous devez définir une unique carte qui sera répétée pour chaque élément."
-          },
-          "loadMore": {
-            "infiniteScroll": "Utiliser le défilement infini",
-            "pagination": "Utiliser la pagination",
-            "title": "Déclencheur pour charger plus de données"
-          },
-          "options": {
-            "ariaLabel": "***"
-          },
-          "static": "Statique"
-        },
-        "tabs": {
-          "addNewTab": "Ajouter un nouvel onglet",
-          "deleteTab": "Supprimer l'onglet"
-        }
-      },
-      "styling": "Modifier le style",
-      "summaryCard": {
-        "dataSource": "Source",
-        "errors": {
-          "invalidSource": "La source de données est invalide : veuillez modifier les paramètres."
-        },
-        "viewAsCards": "Afficher en cartes",
-        "viewAsGrid": "Afficher en grille"
-      },
-      "text": {
-        "aggregations": {
-          "alert": "Vous pouvez créer des agrégations personnalisées et les injecter dans l'éditeur à l'aide d'espaces réservés {{aggregation.<id>}}.",
-          "template": {
-            "add": "Ajouter une nouvelle agrégation de modèles",
-            "edit": "Modifier l'agrégation de modèles"
-          }
-        }
-      }
-    }
-  },
-  "kendo": {
-    "combobox": {
-      "clearTitle": "Supprimer la valeur",
-      "noDataText": "No available choice"
-    },
-    "datepicker": {
-      "dateFormat": "AAAA/MM/JJ ou une expression ({{today}} ou  {{now}})",
-      "dateLabel": "Sélectionnez une date",
-      "endLabel": "Date de fin",
-      "startLabel": "Date de début",
-      "today": "Aujourd'hui",
-      "toggle": "Sélectionnez une date"
-    },
-    "datetimepicker": {
-      "accept": "Accepter",
-      "acceptLabel": "Accepter",
-      "cancel": "Annuler",
-      "cancelLabel": "Annuler",
-      "dateTab": "Date",
-      "dateTabLabel": "Date",
-      "now": "Maintenant",
-      "timeTab": "Heure",
-      "timeTabLabel": "Heure",
-      "today": "Aujourd'hui",
-      "toggle": "Sélectionnez une date et une heure"
-    },
-    "editor": {
-      "addColumnAfter": "Nouvelle colonne à droite",
-      "addColumnBefore": "Nouvelle colonne à gauche",
-      "addRowAfter": "Nouvelle ligne en bas",
-      "addRowBefore": "Nouvelle ligne en haut",
-      "alignCenter": "Centrer",
-      "alignJustify": "Justifier",
-      "alignLeft": "Aligner à gauche",
-      "alignRight": "Aligner à droite",
-      "backColor": "Couleur de fond",
-      "bold": "Gras",
-      "cleanFormatting": "Supprimer le format",
-      "createLink": "Nouveau lien",
-      "deleteColumn": "Supprimer la colonne",
-      "deleteRow": "Supprimer la ligne",
-      "deleteTable": "Supprimer la table",
-      "dialogApply": "Appliquer",
-      "dialogCancel": "Annuler",
-      "dialogInsert": "Insérer",
-      "dialogUpdate": "Modifier",
-      "fileText": "Texte",
-      "fileTitle": "Titre",
-      "fileWebAddress": "Adresse Web",
-      "fontFamily": "Sélectionnez une police de caractère",
-      "fontSize": "Sélectionnez la taille de police",
-      "foreColor": "Couleur",
-      "format": "Format",
-      "imageAltText": "Texte alternatif",
-      "imageHeight": "Hauteur (px)",
-      "imageWebAddress": "Adresse Web",
-      "imageWidth": "Largeur (px)",
-      "indent": "Augmenter le retrait",
-      "insertFile": "Nouveau fichier",
-      "insertImage": "Nouvelle image",
-      "insertOrderedList": "Nouvelle liste ordonnée",
-      "insertTable": "Nouvelle table",
-      "insertUnorderedList": "Nouvelle liste non-ordonnée",
-      "italic": "Italique",
-      "linkOpenInNewWindow": "Ouvrir dans une nouvelle fenêtre",
-      "linkText": "Texte",
-      "linkTitle": "Titre",
-      "linkWebAddress": "Adresse Web",
-      "outdent": "Diminuer le retrait",
-      "print": "Imprimer",
-      "redo": "Répéter",
-      "selectAll": "Tout sélectionner",
-      "strikethrough": "Barrer",
-      "subscript": "Indice",
-      "superscript": "Exposant",
-      "underline": "Souligner",
-      "undo": "Annuler",
-      "unlink": "Supprimer le lien",
-      "unselectAll": "Tout déselectionner",
-      "viewSource": "Voir la source"
-    },
-    "fileselect": {
-      "dropFilesHere": "Déposez les fichiers ici pour les sélectionner",
-      "select": "Choisir des fichiers..."
-    },
-    "grid": {
-      "columnMenu": "'Menu de la colonne {columnName}'",
-      "columns": "Colonnes",
-      "columnsApply": "Appliquer",
-      "columnsReset": "Réinitialiser",
-      "detailCollapse": "Réduire",
-      "detailExpand": "Étendre",
-      "filter": "Filtrer",
-      "filterAfterOperator": "Est après",
-      "filterAfterOrEqualOperator": "Est après ou égal à",
-      "filterAndLogic": "Et",
-      "filterBeforeOperator": "Est avant",
-      "filterBeforeOrEqualOperator": "Est avant ou égal à",
-      "filterBooleanAll": "(Tous)",
-      "filterClearButton": "Effacer",
-      "filterContainsOperator": "Contient",
-      "filterDateToday": "Aujourd'hui",
-      "filterDateToggle": "Afficher/masquer le calendrier",
-      "filterEndsWithOperator": "Termine par",
-      "filterEqOperator": "Est égal à",
-      "filterFilterButton": "Filtrer",
-      "filterGtOperator": "Est plus grand que",
-      "filterGteOperator": "Est plus grand que ou égal à",
-      "filterInputLabel": "'Filtrer {columnName}'",
-      "filterIsEmptyOperator": "Est vide",
-      "filterIsFalse": "est faux",
-      "filterIsInOperator": "Est dans",
-      "filterIsNotEmptyOperator": "Est non-vide",
-      "filterIsNotInOperator": "N'est pas dans",
-      "filterIsNotNullOperator": "Est non-nul",
-      "filterIsNullOperator": "Est nul",
-      "filterIsTrue": "est vrai",
-      "filterLtOperator": "Est plus petit que",
-      "filterLteOperator": "Est plus petit que ou égal à",
-      "filterMenuLogicDropDownLabel": "'Logique de filtre sur {columnName}'",
-      "filterMenuOperatorsDropDownLabel": "'Opérateurs de filtre sur {columnName}'",
-      "filterMenuTitle": "'Menu de filtre sur {columnName}'",
-      "filterNotContainsOperator": "Ne contient pas",
-      "filterNotEqOperator": "Est différent de",
-      "filterNumericDecrement": "Décrémenter la valeur",
-      "filterNumericIncrement": "Incrémenter la valeur",
-      "filterOrLogic": "Ou",
-      "filterStartsWithOperator": "Commence par",
-      "gridLabel": "Table de données",
-      "groupCollapse": "Réduire le groupe",
-      "groupExpand": "Étendre le groupe",
-      "groupPanelEmpty": "Faites glisser un en-tête de colonne et déposez-le ici pour grouper par cette colonne",
-      "loading": "Chargement",
-      "lock": "Verrouiller",
-      "noRecords": "Aucun enregistrement disponible",
-      "pagerFirstPage": "Aller à la première page",
-      "pagerItems": "éléments",
-      "pagerItemsPerPage": "éléments par page",
-      "pagerLabel": "'Navigation de page, page {currentPage} sur {totalPages}'",
-      "pagerLastPage": "Aller à la dernière page",
-      "pagerNextPage": "Aller à la page suivante",
-      "pagerOf": "sur",
-      "pagerPage": "Page",
-      "pagerPageNumberInputTitle": "Numéro de page",
-      "pagerPreviousPage": "Aller à la page précédente",
-      "selectAllCheckboxLabel": "Tout sélectionner",
-      "selectionCheckboxLabel": "Sélectionner la ligne",
-      "setColumnPosition": "Définir la position de la colonne",
-      "sortAscending": "Trier par ordre croissant",
-      "sortDescending": "Trier par ordre décroissant",
-      "sortable": "Triable",
-      "sortedAscending": "Trié par ordre croissant",
-      "sortedDefault": "Non trié",
-      "sortedDescending": "Trié par ordre décroissant",
-      "stick": "Épingler",
-      "unlock": "Déverrouiller",
-      "unstick": "Désépingler"
-    },
-    "multiselect": {
-      "clearTitle": "Supprimer la valeur",
-      "noDataText": "No available choice"
-    },
-    "pager": {
-      "firstPage": "Aller à la première page",
-      "items": "éléments",
-      "itemsPerPage": "éléments par page",
-      "label": "'Navigation de page, page {currentPage} sur {totalPages}'",
-      "lastPage": "Aller à la dernière page",
-      "nextPage": "Aller à la page suivante",
-      "of": "sur",
-      "page": "Page",
-      "pageNumberInputTitle": "Numéro de page",
-      "previousPage": "Aller à la page précédente"
-    },
-    "tilelayout": {
-      "component": {
-        "items": "articles",
-        "itemsPerPage": "Articles par page",
-        "of": "de",
-        "page": "Page"
-      }
-    },
-    "timepicker": {
-      "accept": "Accepter",
-      "acceptLabel": "Accepter",
-      "cancel": "Annuler",
-      "cancelLabel": "Annuler",
-      "now": "Maintenant",
-      "toggle": "Sélectionner une heure"
-    },
-    "upload": {
-      "dropFilesHere": "Déposez les fichiers ici pour les importer",
-      "invalidMaxFileSize": "Taille du fichier trop grande.",
-      "select": "Sélectionner les fichiers..."
-    }
-  },
-  "models": {
-    "apiConfiguration": {
-      "authType": "Type d'authentification",
-      "new": "Nouvelle configuration d'API",
-      "selectAuthType": "Sélectionnez le type d'authentification"
-    },
-    "application": {
-      "description": "Description",
-      "errors": {
-        "style": {
-          "notFound": "Le style de l'application n'a pas pu être chargé"
-        }
-      },
-      "id": "ID de l'application",
-      "menu": "Menu latéral",
-      "new": "Nouvelle application",
-      "notifications": {
-        "notPublished": "L'application n'a pas pu être publiée.",
-        "published": "L'application {{value}} a été publiée.",
-        "updated": "Application modifiée."
-      },
-      "setAsFavorite": "Ajouter aux favoris",
-      "subscription": {
-        "create": "Créer un abonnement"
-      }
-    },
-    "channel": {
-      "create": "Créer un canal de diffusion",
-      "edit": "Modifier le canal",
-      "new": "Nouveau canal de diffusion"
-    },
-    "customNotification": {
-      "lastExecution": "Dernière exécution",
-      "schedule": "Fréquence",
-      "type": "Type"
-    },
-    "dashboard": {
-      "activateFiltering": "Activer le filtre",
-      "buttonActions": {
-        "add": "Ajouter une action de bouton",
-        "category": "Catégorie de bouton",
-        "confirmDelete": "Voulez-vous vraiment supprimer cette action de bouton ?",
-        "edit": "Modifier l'action du bouton",
-        "href": {
-          "title": "Bouton href",
-          "tooltip": "L'attribut href spécifie l'URL de destination lorsque le bouton est cliqué. Peut être une URL relative ou absolue."
-        },
-        "one": "Action du bouton",
-        "openInNewTab": "Ouvrir dans un nouvel onglet",
-        "text": "Texte du bouton",
-        "variant": "Variante de bouton"
-      },
-      "closable": "Peut être fermé",
-      "context": {
-        "datasource": {
-          "alert": "Sélectionnez une source de données, afin de définir une page par enregistrement de la source de données. Vous pouvez également définir un modèle qui sera chargé par défaut si aucune page spécifique n'est créée pour un enregistrement.",
-          "info": "Indiquez le champ à utiliser lors de la sélection des enregistrements.",
-          "set": "Définir la source de données contextuelle",
-          "title": "Source de données contextuelle",
-          "update": "Mettre à jour la source de données contextuelle"
-        },
-        "displayField": "Champ d'affichage",
-        "edition": {
-          "element": "Vous éditez la page qui sera affichée pour l'élément sélectionné.",
-          "template": "Vous éditez le modèle de base de la page. Il sera utilisé par défaut si aucune vue n'a été créée pour l'élément à charger."
-        },
-        "notifications": {
-          "creatingTemplate": "Création d'une nouvelle vue",
-          "loadDefault": "Affichage de la vue générique",
-          "templateCreated": "Nouvelle vue créée"
-        },
-        "origin": "Origine du contexte",
-        "refData": {
-          "element": "Élément"
-        },
-        "selectDisplayField": "Sélectionnez le champ d'affichage",
-        "selectOrigin": "Sélectionnez la source de données",
-        "title": "Contexte",
-        "tooltip": {
-          "useContextEditor": "Utiliser l'éditeur de contexte",
-          "useDefaultEditor": "Utiliser l'éditeur par défaut"
-        }
-      },
-      "contextFilter": "Filtre contextuel",
-      "dashboardFilter": "Filtre du tableau de bord",
-      "deactivateFiltering": "Désactiver le filtre",
-      "filterVariant": {
-        "title": "Variante de filtre",
-        "variantsOptions": {
-          "selectOrigin": "Sélectionner une variante de filtre",
-          "variant_default": "Défaut",
-          "variant_modern": "Moderne"
-        }
-      },
-      "historicalDate": "Récupérer les données historiques",
-      "share": "Partager le tableau de bord",
-      "tooltip": {
-        "filter": {
-          "closable": "Lorsque la variante est moderne ou que l'application est utilisée comme élément web, un bouton s'affichera pour permettre à l'utilisateur de cacher le filtre",
-          "fields": "Vous pouvez utiliser les champs du filtre du tableau de bord, ou utiliser des valeurs statiques.",
-          "position": "Ne s'applique que lorsque la variant par défaut est active"
-        },
-        "historicalDate": "Vous pouvez récupérer les données à une date spécifique en utilisant un champ du filtre du tableau de board.\nVeuillez alors utiliser cette syntaxe : {{filter.<nom>}}."
-      }
-    },
-    "form": {
-      "core": "Source",
-      "create": "Créer un formulaire",
-      "edit": "Modifier le formulaire",
-      "field": {
-        "itemsLabel": "Éléments d'étiquette",
-        "label": "Étiquette",
-        "name": "Nom du champ",
-        "usedIn": "Utilisé par"
-      },
-      "new": "Nouveau formulaire",
-      "notifications": {
-        "savingFailed": "Échec de l'enregistrement, certains champs nécessitent votre attention."
-      },
-      "select": "Sélectionner un formulaire",
-      "template": "Modèle"
-    },
-    "group": {
-      "create": "Créer un groupe",
-      "description": "Description",
-      "fetch": "Récupérer les groupes du service",
-      "title": "Titre"
-    },
-    "mapping": {
-      "add": "Ajouter un rang à la table de correspondances",
-      "edit": "Modifier un rang de la table de correspondances"
-    },
-    "page": {
-      "add": "Ajouter une page",
-      "tooltip": {
-        "drag": "Glissez-déposez pour réorganiser",
-        "duplicate": "Sélectionner l'application où copier la page"
-      }
-    },
-    "positionAttribute": {
-      "edit": "Modifier l'attribut de position",
-      "new": "Nouvel attribut de position"
-    },
-    "pullJob": {
-      "edit": "Modifier une tâche planifiée",
-      "new": "Nouvelle tâche planifiée",
-      "nextIteration": "Prochaine exécution",
-      "path": "Chemin",
-      "schedule": "Horaire planifié",
-      "url": "Url"
-    },
-    "record": {
-      "convert": "Convertir",
-      "edit": "Modifier l'enregistrement",
-      "new": "Nouvel enregistrement",
-      "notifications": {
-        "conversionIncomplete": "Il n'y a pas de correspondance entre le(s) enregistrement(s) sélectionné(s) et certains champs de ce formulaire.",
-        "rowsAdded": "{{length}} ligne(s) ont été ajoutées à {{field}} dans l'enregistrement {{value}}.",
-        "rowsNotAdded": "Erreur lors de l'ajout de ligne(s).",
-        "uploadSuccessful": "Enregistrements importés avec succès"
-      },
-      "restore": "Restaurer",
-      "select": "Sélectionnez un enregistrement"
-    },
-    "referenceData": {
-      "add": "Ajouter une référence de données",
-      "select": "Sélectionnez une référence de données"
-    },
-    "resource": {
-      "create": "Créer une ressource",
-      "select": "Sélectionnez une ressource"
-    },
-    "role": {
-      "create": "Créer un rôle",
-      "description": "Description",
-      "title": "Titre"
-    },
-    "step": {
-      "new": "Nouvelle étape"
-    },
-    "subscription": {
-      "edit": "Modifier l'abonnement",
-      "new": "Nouvel abonnement"
-    },
-    "user": {
-      "firstName": "Prénom",
-      "lastName": "Nom",
-      "notifications": {
-        "rolesUpdated": "Les rôles de {{username}} ont été modifiés.",
-        "userImportFail": "L'importation d'utilisateurs a échoué."
-      },
-      "username": "Nom d'utilisateur"
-    },
-    "widget": {
-      "add": "Ajouter un widget",
-      "chart": {
-        "defaultTitle": "Widget Graphique"
-      },
-      "delete": {
-        "confirmationMessage": "Souhaitez-vous supprimer le widget ?",
-        "title": "Supprimer le widget"
-      },
-      "display": {
-        "border": "Afficher la bordure du widget",
-        "expand": "Afficher le bouton pour développer le widget",
-        "header": "Afficher l'en-tête du widget",
-        "padding": "Utiliser la marge intérieure du widget",
-        "searchable": "Autoriser la recherche",
-        "sortable": "Autoriser le tri",
-        "title": "Affichage des widgets",
-        "tooltip": "afficher l'info-bulle"
-      },
-      "map": {
-        "defaultTitle": "Widget Carte",
-        "latitude": "Latitude",
-        "longitude": "Longitude",
-        "zoom": "Zoom"
-      },
-      "sorting": {
-        "add": "Ajouter un champ",
-        "delete": "Supprimer le champ de tri",
-        "empty": "Aucun champ de tri défini",
-        "field": "Champ",
-        "label": "Étiquette",
-        "management": "Gestion des champs de tri",
-        "order": "Ordre",
-        "select": "Sélectionnez un champ de tri...",
-        "title": "Tri"
-      },
-      "tooltip": {
-        "expandButton": {
-          "expand": "Étendre le widget",
-          "help": "Apparaît uniquement dans le front-office ou en mode prévisualisation.",
-          "restore": "Restaurer la taille"
-        },
-        "selector": {
-          "collapse": "Fermer la sélection de widget",
-          "expand": "Afficher la sélection de widget"
-        }
-      }
-    },
-    "workflow": {
-      "notifications": {
-        "cannotGoToNextStep": "Impossible de passer à l'étape suivante",
-        "cannotGoToPreviousStep": "Impossible de passer à l'étape précédente",
-        "goToStep": "De retour à l'étape {{step}}."
-      }
-    }
-  },
-  "pages": {
-    "administration": {
-      "title": "Administration"
-    },
-    "aggregation": {
-      "preview": {
-        "label": "Aperçu des données d'agrégation",
-        "missingAggregation": "Impossible de charger l'agrégation sélectionnée. Agrégation introuvable"
-      }
-    },
-    "apiConfiguration": {
-      "authentication": "Paramètres d'authentification",
-      "baseUrl": "Point d'arrivée principal",
-      "clientId": "ID Client",
-      "graphQL": {
-        "endpoint": "Point d'accès GraphQL",
-        "title": "Paramètres de GraphQL"
-      },
-      "host": "Paramètres de l'hôte",
-      "notifications": {
-        "authTokenFetched": "Jeton d'authentification récupéré, faîtes un autre ping pour obtenir la vraie réponse.",
-        "pingFailed": "La requête ping a échoué.",
-        "pingReceived": "La requête ping a reçu une réponse positive."
-      },
-      "ping": "Essayer avec ces paramètres",
-      "pingUrl": "Extension ping",
-      "placeholder": {
-        "baseUrl": "URL de base pour l'API",
-        "clientId": "Entrez l'ID Client",
-        "graphQLEndpoint": "Extension GraphQL",
-        "pingUrl": "Entrez l'URL de l'extension ping",
-        "scope": "Entrer le scope",
-        "secret": "Entrer le client secret",
-        "token": "Entrez le jeton d'accès pour l'authentification",
-        "tokenUrl": "Entrez l'URL du jeton d'accès"
-      },
-      "scope": "Scope",
-      "secret": "Client Secret",
-      "token": "Jeton d'accès",
-      "tokenUrl": "URL du jeton d'accès"
-    },
-    "apiConfigurations": {
-      "create": "Créer une configuration d'API"
-    },
-    "appBuilder": {
-      "title": "Création de site"
-    },
-    "application": {
-      "addPage": {
-        "form": {
-          "title": "Formulaires disponibles"
-        },
-        "selectType": "Sélectionnez le type de page que vous voulez créer",
-        "startFromWidget": "Commencer avec un widget"
-      },
-      "empty": {
-        "add": "Ajouter une page",
-        "create": "Cliquez sur créer pour terminer le processus",
-        "customize": "Personnalisez chacune des pages créées"
-      },
-      "positionAttributes": {
-        "create": "Créer une catégorie de position",
-        "title": "Attributs"
-      },
-      "settings": {
-        "actions": "Actions"
-      }
-    },
-    "applications": {
-      "all": "Toutes les applications",
-      "goTo": "Aller vers la liste d'applications",
-      "recent": "Applications récentes",
-      "title": "Mes applications"
-    },
-    "dashboard": {
-      "update": {
-        "exit": "Quitter sans sauvegarder les changements",
-        "exitMessage": "Il y a des changements non sauvegardés dans la page, voulez-vous vraiment quitter cette page ?"
-      }
-    },
-    "formBuilder": {
-      "errors": {
-        "choices": {
-          "valueDuplicated": "Veuillez configurer des valeurs uniques pour les choix de la question : {{question}}"
-        },
-        "dataFieldDuplicated": "Doublon de nom de valeur : {{name}}. Indiquez un nom de valeur distinct pour chaque question.",
-        "missingName": "Nom manquant pour un élément de la page : {{page}}. Veuillez configurer un nom valide (en format snake_case) pour sauvegarder le formulaire.",
-        "multipletext": {
-          "missingName": "Veuillez configurer un nom ou titre pour chaque champ de text de la question : {{question}}"
-        },
-        "selectApplication": "Application manquante pour un élément de la page : {{page}}. Veuillez sélectionner au moins une application dans les propriétés de {{question}} pour sauvegarder le formulaire.",
-        "snakecase": "Le nom de valeur {{name}} de la page {{page}} est invalide. Veuillez configurer un nom valide (en format snake_case) pour sauvegarder le formulaire."
-      },
-      "move": {
-        "down": "Descendre la question",
-        "up": "Monter la question"
-      },
-      "questionsCategories": {
-        "core": "Bibliothèque de questions"
-      },
-      "title": "Paramètres avancés"
-    },
-    "forms": {
-      "title": "Formulaires disponibles"
-    },
-    "profile": {
-      "notifications": {
-        "notUpdated": "Erreur lors de l'enregistrement des préférences.",
-        "updated": "Préférences sauvegardées."
-      },
-      "title": "Votre profil",
-      "password": {
-        "change": "Changer le mot de passe"
-      }
-    },
-    "pullJobs": {
-      "create": "Créer une tâche planifiée"
-    },
-    "referenceData": {
-      "csv": "Fichier CSV d'entrée",
-      "fields": {
-        "fetch": "Récupérer les champs",
-        "help": "Les champs sont calculés en fonction des attributs du premier élément dans la réponse de l'API",
-        "missingConfig": "Impossible de récupérer les champs. Configuration manquante : {{config}}",
-        "noFields": "Aucun champ trouvé",
-        "title": "Champ"
-      },
-      "graphQLFilter": "Paramètres de la requête GraphQL",
-      "pagination": {
-        "cursorPath": "Chemin du curseur",
-        "cursorVariable": "Variable de requête de curseur",
-        "offsetVariable": "Variable de requête de décalage",
-        "pageSizeVariable": "Variable de requête de taille de page",
-        "pageVariable": "Variable de requête de numéro de page",
-        "strategy": "Stratégie de pagination",
-        "totalCountPath": "Chemin du nombre total d'articles",
-        "usePagination": {
-          "hint": "Dépend de la prise en charge de l'API, permet de récupérer des données par page",
-          "text": "Utiliser la pagination"
-        }
-      },
-      "path": {
-        "placeholder": "Entrez un JSONPath valide",
-        "title": "Chemin de données"
-      },
-      "payload": {
-        "label": "Réponse de l'API",
-        "show": "Afficher la réponse de l'API"
-      },
-      "placeholder": {
-        "csv": "Insérer le CSV ici",
-        "graphQLFilter": "Entrez un filtre graphQL qui sera utilisé une fois les choix cachés"
-      },
-      "queryName": "Nom de la requête",
-      "tooltip": {
-        "graphQLFilter": "Vous pouvez utiliser {{lastUpdate}} pour obtenir dynamiquement la dernière date de récupération au format SQL.",
-        "path": "Utilise la syntaxe JSONPath pour extraire les éléments de la réponse JSON. Exemples: $.data[*].name, $.data..countries, $.data.countries.*"
-      },
-      "type": "Type",
-      "validateCsv": "Valider le CSV",
-      "valueField": "Champ de valeur"
-    },
-    "workflow": {
-      "addStep": {
-        "selectType": "Sélectionner quel type d'étape vous voulez créer."
-      },
-      "deleteStep": {
-        "confirmationMessage": "Souhaitez-vous supprimer définitivement l'étape {{step}} ?"
-      },
-      "empty": {
-        "add": "Ajoutez des étapes",
-        "customize": "Personnalisez chacune des étapes créées."
-      }
-    }
-  }
+	"common": {
+		"access": "Accès",
+		"accessDenied": "Accès refusé",
+		"account": "Compte",
+		"actions": "Actions",
+		"add": "Ajouter",
+		"adminField": "Champ administrateur",
+		"aggregation": {
+			"add": "Ajouter une agrégation",
+			"few": "Agrégations",
+			"none": "Aucune agrégation",
+			"one": "Agrégation"
+		},
+		"apiConfiguration": {
+			"few": "Configurations d'API",
+			"none": "Aucune configuration d'API",
+			"one": "Configuration d'API"
+		},
+		"application": {
+			"few": "Applications",
+			"none": "Aucune application",
+			"one": "Application"
+		},
+		"archive": {
+			"delete": "Supprimer",
+			"few": "Archives",
+			"modal": {
+				"delete": {
+					"action": "Supprimer",
+					"confirmationMessage": "Voulez-vous supprimer l'archive {{name}}?",
+					"title": "Supprimer?"
+				},
+				"restore": {
+					"action": "Restaurer",
+					"confirmationMessage": "Voulez-vous restaurer {{name}}?",
+					"title": "Restaurer?"
+				}
+			},
+			"none": "Aucun élément archivé",
+			"restore": "Restaurer"
+		},
+		"ariaLabel": {
+			"search": {
+				"clear": "Supprimer la recherche"
+			}
+		},
+		"asc": "Croissant",
+		"attribute": {
+			"few": "Attributs",
+			"none": "Aucun attribut",
+			"one": "Attribut"
+		},
+		"auto": "Automatique",
+		"back": "Retour",
+		"bookmarks": "Marque-pages",
+		"calculatedField": {
+			"few": "Champs dérivés",
+			"none": "Aucun champ dérivé",
+			"one": "Champ dérivé"
+		},
+		"cancel": "Annuler",
+		"channel": {
+			"few": "Canaux de diffusion",
+			"none": "Aucun canal de diffusion",
+			"one": "Canal de diffusion"
+		},
+		"child": {
+			"edit": "Modifier l'enfant",
+			"one": "Enfant"
+		},
+		"clear": "Annuler",
+		"close": "Fermer",
+		"column": {
+			"few": "Colonnes",
+			"none": "Aucune colonne",
+			"one": "Colonne"
+		},
+		"comma": "virgule",
+		"copy": "Copier",
+		"create": "Créer",
+		"createdOn": "Date de création",
+		"cronEditor": {
+			"advanced": "Avancé",
+			"atTime": "À",
+			"daily": "Quotidien",
+			"day": "Jour",
+			"days": "Jour(s)",
+			"every": {
+				"feminine": "Toutes les",
+				"masculine": "Tous les"
+			},
+			"firstWeekDay": "Premier jour de la semaine",
+			"hourly": "Horaire",
+			"hours": "Heure(s)",
+			"lastDay": "Dernier jour",
+			"lastWeekDay": "Dernier jour de la semaine",
+			"minutely": "Chaque minute",
+			"minutes": "Minute(s)",
+			"month": "Mois",
+			"monthly": "Mensuel",
+			"months": {
+				"april": "Avril",
+				"august": "Août",
+				"december": "Décembre",
+				"february": "Février",
+				"january": "Janvier",
+				"july": "Juillet",
+				"june": "Juin",
+				"march": "Mars",
+				"may": "Mai",
+				"november": "Novembre",
+				"october": "Octobre",
+				"september": "Septembre"
+			},
+			"of": "du",
+			"ofEvery": "de chaque",
+			"onThe": {
+				"feminine": "Pendant la",
+				"masculine": "Pendant le"
+			},
+			"seconds": "Seconde(s)",
+			"week": "Semaine",
+			"weekDay": "Jour de la semaine (LUN-VEN)",
+			"weekDays": {
+				"friday": "Vendredi",
+				"monday": "Lundi",
+				"saturday": "Samedi",
+				"sunday": "Dimanche",
+				"thursday": "Jeudi",
+				"tuesday": "Mardi",
+				"wednesday": "Mercredi"
+			},
+			"weekNumber": {
+				"fifth": "Cinquième",
+				"first": "Première",
+				"fourth": "Quatrième",
+				"last": "Dernière",
+				"second": "Deuxième",
+				"third": "Troisième"
+			},
+			"weekly": "Hebdomadaire",
+			"yearly": "Annuel"
+		},
+		"customNotification": {
+			"few": "Notifications",
+			"none": "Aucune notification",
+			"one": "Notification"
+		},
+		"dashboard": {
+			"few": "Tableaux de bord",
+			"none": "Aucun tableau de bord",
+			"one": "Tableau de bord"
+		},
+		"delete": "Supprimer",
+		"deleteObject": "Supprimer {{name}}",
+		"deleted": "Supprimé",
+		"desc": "Décroissant",
+		"dismiss": "Fermer",
+		"display": "Afficher",
+		"distributionList": {
+			"few": "Listes de distribution",
+			"none": "Aucune liste de distribution",
+			"one": "Liste de distribution"
+		},
+		"downloadObject": "Télécharger {{name}}",
+		"downloadTemplate": "Télécharger le modèle",
+		"duplicate": "Dupliquer",
+		"edit": "Modifier",
+		"email": {
+			"few": "Emails",
+			"none": "Pas d'email",
+			"one": "Email"
+		},
+		"errors": {
+			"few": "Erreurs",
+			"objectDuplicated": "{{type}} {{value}} existe déjà."
+		},
+		"exitFullscreen": "Quitter le mode plein écran",
+		"export": "Exporter",
+		"exportObject": "Exporter {{name}}",
+		"false": "Faux",
+		"field": {
+			"few": "Champs",
+			"none": "Aucun champ",
+			"one": "Champ"
+		},
+		"filter": {
+			"apply": "Appliquer",
+			"clear": "Supprimer le filtre",
+			"empty": "Aucun résultat",
+			"few": "Filtres",
+			"hide": "Cacher le filtre",
+			"none": "Pas de filtre",
+			"one": "Filtre",
+			"show": "Afficher le filtre"
+		},
+		"form": {
+			"few": "Formulaires",
+			"none": "Aucun formulaire",
+			"one": "Formulaire"
+		},
+		"general": "Général",
+		"group": {
+			"few": "Groupes",
+			"none": "Pas de groupes",
+			"one": "Groupe"
+		},
+		"hide": "Cacher",
+		"history": "Historique",
+		"id": "Id",
+		"input": {
+			"dateRange": "Intervalle de dates",
+			"none": "-- Aucun --",
+			"rawJson": "JSON brut"
+		},
+		"label": "Etiquette",
+		"layers": {
+			"few": "Couches",
+			"none": "Pas de couche"
+		},
+		"layout": {
+			"few": "Mises en page",
+			"none": "Aucune mise en page",
+			"one": "Mise en page"
+		},
+		"loading": "Chargement",
+		"modifiedOn": "Modifié le ",
+		"name": "Nom",
+		"next": "Suivant",
+		"noOptions": "Aucun choix disponible",
+		"notifications": {
+			"accessDenied": "Vous n'avez pas la permission pour accéder à cet objet de type {{type}}.",
+			"accessNotProvided": "Pas d'accès fourni à cet objet de type {{type}}. {{error}}",
+			"alreadyExists": "Cet objet {{type}} {{value}} existe déjà dans cette application.",
+			"copiedToClipboard": "Lien du tableau de bord copié !",
+			"dataNotRecovered": "Échec de la récupération des données",
+			"dataRecovered": "Les données ont été récupérées !",
+			"email": {
+				"error": "Un problème est survenu lors de l'envoi de l'e-mail",
+				"errors": {
+					"noDistributionList": "Un problème est survenu lors de l'envoi de l'e-mail: aucune liste de distribution détectée",
+					"noTemplate": "Un problème est survenu lors de l'envoi de l'e-mail: aucun template détecté"
+				},
+				"processing": "Envoi en cours...",
+				"ready": "E-mail prêt",
+				"sent": "E-mail envoyé"
+			},
+			"fetchingGroups": "Fetching groups from service...",
+			"file": {
+				"download": {
+					"error": "Un problème est survenu lors du téléchargement",
+					"ongoing": "Votre téléchargement est en cours. Vous recevrez bientôt un e-mail contenant votre fichier.",
+					"processing": "Téléchargement du fichier en cours...",
+					"ready": "Votre fichier est prêt"
+				},
+				"upload": {
+					"error": "Un problème est survenu lors de l'import",
+					"maxFileSize": "La taille maximale du fichier est de {{size}} Mo.",
+					"processing": "Fichier en cours d'importation...",
+					"ready": "Fichier importé"
+				}
+			},
+			"formStatus": "Le statut actuel du formulaire ne permet pas son affichage.",
+			"formatInvalid": "Veuillez importer un fichier de format .{{format}}.",
+			"groups": {
+				"error": "Une erreur s'est produite lors de la tentative d'obtenir des groupes du service",
+				"processing": "Récupération des groupes à partir du service...",
+				"ready": "Groupes récupérés"
+			},
+			"history": {
+				"error": "Un problème est survenu lors de la génération de l'historique. {{error}}"
+			},
+			"loadedFromCache": "Objet de type {{type}} chargé depuis le cache.",
+			"noOpened": "Aucun objet {{value}} n'a été ouvert.",
+			"objectCreated": "{{value}} {{type}} créé avec succès.",
+			"objectDeleted": "{{value}} supprimé avec succès.",
+			"objectDuplicated": "{{type}} {{value}} dupliqué avec succès.",
+			"objectInvited": "{{name}} a été invité.",
+			"objectLocked": "L'édition de {{name}} a été bloquée par un autre utilisateur.",
+			"objectNotCreated": "L'objet de type {{type}} n'a pas pu être créé. {{error}}",
+			"objectNotDeleted": "L'objet {{value}} n'a pas pu être supprimé. {{error}}",
+			"objectNotDuplicated": "L'objet de type {{type}} n'a pas pu être dupliqué. {{error}}",
+			"objectNotFound": "{{name}} n'a pas été trouvé.",
+			"objectNotInvited": "L'invitation vers {{name}} a échoué.",
+			"objectNotReordered": "{{type}} non réorganisé. {{error}}",
+			"objectNotRestored": "{{value}} non restauré. {{error}}",
+			"objectNotUpdated": "L'objet de type {{type}} n'a pas pu être modifié. {{error}}",
+			"objectReordered": "L'objet de type {{type}} a été réorganisé.",
+			"objectRestored": "{{value}} restauré.",
+			"objectUpdated": "{{value}} {{type}} a été modifié.",
+			"platformAccessNotGranted": "Vous n'avez pas d'accès valide à cette plateforme.",
+			"readAll": "Tout marqué comme lu",
+			"statusUpdated": "Statut mis à jour par {{value}}.",
+			"unlocked": "L'édition de l'objet {{name}} a été débloquée par un autre utilisateur."
+		},
+		"openFullScreen": "Ouvrir en plein écran",
+		"options": "Options",
+		"or": "Ou",
+		"page": {
+			"few": "Pages",
+			"none": "Aucune page",
+			"one": "Page"
+		},
+		"pagination": {
+			"empty": "Aucun résultat",
+			"itemsPerPage": "Éléments par page",
+			"loadMore": "Charger plus",
+			"of": "de"
+		},
+		"placeholder": {
+			"address": "Entrez une adresse exemple : 1 rue de la paix, Paris",
+			"email": "Entrez un email",
+			"name": "Entrez un nom",
+			"search": "Rechercher...",
+			"title": "Entrez un titre"
+		},
+		"platform": {
+			"backOffice": "Back-Office"
+		},
+		"position": {
+			"bottomleft": "En bas à gauche",
+			"bottomright": "En bas à droite",
+			"topleft": "En haut à gauche",
+			"topright": "En haut à droite"
+		},
+		"positionAttribute": {
+			"few": "Attributs de position",
+			"none": "Aucun attribut de position",
+			"one": "Attribut de position"
+		},
+		"positionCategory": {
+			"few": "Catégories de position",
+			"none": "Aucune catégorie de position",
+			"one": "Catégories de position"
+		},
+		"preview": "Prévisualisation",
+		"previous": "Précédent",
+		"publish": "Publier",
+		"pullJob": {
+			"few": "Tâches planifiées",
+			"none": "Aucune tâche planifiée",
+			"one": "Tâche planifiée"
+		},
+		"record": {
+			"few": "Enregistrements",
+			"none": "Pas d'enregistrement",
+			"one": "Enregistrement"
+		},
+		"referenceData": {
+			"few": "Références de données",
+			"none": "Aucune référence de données",
+			"one": "Référence de données"
+		},
+		"remove": "Retirer",
+		"resource": {
+			"few": "Ressources",
+			"none": "Aucune ressource",
+			"one": "Ressource"
+		},
+		"role": {
+			"few": "Rôles",
+			"none": "Aucun rôle",
+			"one": "Rôle"
+		},
+		"row": {
+			"few": "Rangées",
+			"none": "Aucune rangée",
+			"one": "Rangée",
+			"update": {
+				"few": {
+					"content": "Souhaitez vous mettre à jour les {{count}} enregistrements?",
+					"title": "Mise à jour des enregistrements"
+				},
+				"one": {
+					"content": "Souhaitez vous mettre à jour l’enregistrement?",
+					"title": "Mise à jour de l’enregistrement"
+				}
+			}
+		},
+		"save": "Sauvegarder",
+		"saveChanges": "Sauvegarder les changements",
+		"search": "Recherche",
+		"searchObject": "Rechercher {{name}}",
+		"select": "Sélectionner",
+		"selectStatus": "Sélectionner un statut",
+		"semicolon": "point-virgule",
+		"send": "Envoyer",
+		"separator": "Séparateur",
+		"settings": "Paramètres",
+		"status": "Statut",
+		"status_active": "Actif",
+		"status_archived": "Archivé",
+		"status_pending": "Inactif",
+		"step": {
+			"few": "Etape",
+			"none": "Aucune étape",
+			"one": "Etape"
+		},
+		"subscription": {
+			"few": "Abonnements",
+			"none": "Aucun abonnement",
+			"one": "Abonnement"
+		},
+		"tabs": "Onglets",
+		"template": {
+			"few": "Modèles de notification",
+			"none": "Aucun modèle",
+			"one": "Modèle de notification"
+		},
+		"title": "Titre",
+		"tooltip": {
+			"dragDrop": "Glissez-déposez pour réorganiser",
+			"editor": {
+				"insert": "Tapez '{' pour utiliser des expressions et des variables"
+			}
+		},
+		"true": "Vrai",
+		"type": {
+			"few": "Types",
+			"none": "Aucun type",
+			"one": "Type"
+		},
+		"update": "Mettre à jour",
+		"updateObject": "Mettre à jour {{name}}",
+		"uploadObject": "Importer {{name}}",
+		"user": {
+			"few": "Utilisateurs",
+			"none": "Aucun utilisateur",
+			"one": "Utilisateur"
+		},
+		"value": {
+			"few": "Valeurs",
+			"none": "Aucune valeur",
+			"one": "Valeur"
+		},
+		"viewFullscreen": "Ouvrir le mode plein écran",
+		"viewObject": "Voir {{name}}",
+		"workflow": {
+			"few": "Workflows",
+			"none": "Aucun workflow",
+			"one": "Workflow"
+		}
+	},
+	"components": {
+		"access": {
+			"canDelete": "Peut supprimer",
+			"canSee": "Peut voir",
+			"canUpdate": "Peut modifier",
+			"description": "Modifier les permissions de {{name}}",
+			"title": "Accès"
+		},
+		"aggregation": {
+			"add": {
+				"choice": {
+					"create": "Créer une nouvelle agrégation",
+					"load": "Charger une agrégation"
+				},
+				"select": "Sélectionner une agrégation",
+				"title": "Ajouter une agrégation"
+			},
+			"edit": {
+				"title": "Paramètres d'agrégation"
+			}
+		},
+		"aggregationBuilder": {
+			"accumulators": "Accumulateurs",
+			"addField": "Ajouter un champ",
+			"addRule": "Ajouter une règle",
+			"addStage": "Ajouter une étape",
+			"dataset": {
+				"select": "Sélectionner la source de données"
+			},
+			"fieldName": "Nom du champ",
+			"groupBy": "Regrouper par",
+			"groupingRules": "Grouper par",
+			"mapping": {
+				"category": "Catégorie",
+				"field": "Valeur",
+				"series": "Séries"
+			},
+			"operator": "Opérateur",
+			"operators": {
+				"add": "Ajouter",
+				"avg": "Moyenne",
+				"count": "Compte",
+				"day": "Jour",
+				"first": "Premier",
+				"last": "Dernier",
+				"max": "Maximum",
+				"min": "Minimum",
+				"month": "Mois",
+				"multiply": "Multiplier",
+				"sum": "Somme",
+				"week": "Semaine",
+				"year": "Année"
+			},
+			"preview": {
+				"hide": "Masquer l'aperçu",
+				"show": "Afficher l'aperçu"
+			},
+			"sourceFields": "Sélectionner les champs",
+			"stages": {
+				"addFields": "Ajouter des champs",
+				"custom": "Personnaliser",
+				"filter": "Filtrer",
+				"group": "Grouper & Accumulateur",
+				"sort": "Trier",
+				"unwind": "Dissocier"
+			},
+			"tooltip": {
+				"addFields": "Ajouter de nouveaux champs au document.",
+				"custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
+				"filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
+				"group": "Regroupe les enregistrements en fonction des valeurs de champ et construit des accumulateurs personnalisés.",
+				"groupingRules": "Les règles de regroupement sont facultatives.",
+				"selectedFields": "Seuls les champs non utilisés peuvent être supprimés.",
+				"sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.\nLa mise en place de des étapes de tri successives triera simultanément tous les champs.",
+				"unwind": "Déconstruit un tableau depuis les documents d'entrée et ressort un document pour chaque élément."
+			}
+		},
+		"apiConfiguration": {
+			"create": {
+				"errors": {
+					"name": "Nom invalide: utilisez seulement des lettres, des chiffres et des tirets bas."
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer la configuration d'API {{name}} ?",
+				"title": "Supprimer la configuration d'API"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page de configurations d'API"
+			}
+		},
+		"application": {
+			"archive": {
+				"autoDeletedAt": "Date de suppression automatique",
+				"name": "Nom"
+			},
+			"customStyling": "Style personnalisé",
+			"dashboard": {
+				"clearFields": "Supprimer les champs",
+				"editFilter": "Modifier le filtre",
+				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée.",
+				"enterEditMode": "Entrer en mode édition",
+				"enterPreviewMode": "Entrer en mode prévisualisation",
+				"filter": {
+					"empty": "Aucun filtre n'a été défini par les administrateurs",
+					"filterPosition": {
+						"bottom": "Afficher le filtre en bas",
+						"left": "Afficher le filtre à gauche",
+						"right": "Afficher le filtre à droite",
+						"top": "Afficher le filtre en haut",
+						"unset": "Position indéfinie, sélectionnez en une"
+					},
+					"info": "Les filtres de tableau de bord peuvent être utilisés entre les pages pour filtrer leur contenu.",
+					"title": "Vous modifiez les filtres du tableau de bord"
+				},
+				"filterSettings": "Paramètres du filtre",
+				"settings": {
+					"defaultPosition": "Position par défaut du filtre",
+					"fixedRowHeight": "Hauteur de ligne fixe",
+					"gridOptions": "Options de grille",
+					"gridType": {
+						"fit": "Ajuster",
+						"placeholder": "Sélectionnez un type de grille",
+						"title": "Type de grille",
+						"verticalFixed": "Vertical fixe"
+					},
+					"help": {
+						"minCols": "Réduire le nombre de colonnes peut ne pas avoir un impact direct si les widgets dépassent la limite spécifiée en largeur."
+					},
+					"margin": "Marge entre les widgets",
+					"minCols": "Nombre de colonnes",
+					"minimumHeight": "Hauteur minimum",
+					"tooltip": {
+						"fixedRowHeight": "Taille des lignes en pixels.\nDoit être supérieur ou égal à 50.",
+						"margin": "Marge entre les widgets.\nDoit être un entier positif.",
+						"minCols": "Nombre de colonnes.\nDoit être compris entre 4 et 24.",
+						"minimumHeight": "Taille minimale de la grille en pixels.\nDoit être supérieur ou égal à 0.",
+						"reset": "Réinitialiser la valeur"
+					},
+					"tooltips": {
+						"clear": "Définir les valeurs par défaut",
+						"fixedRowHeight": "Minimum: 50, Par défaut: 200, Pas de max",
+						"margin": "Minimum: 0, Par défaut: 10, Pas de max",
+						"minCols": "Minimum: 4, Par défaut: 8, Maximum: 24"
+					}
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer cette application ?"
+			},
+			"duplicate": {
+				"name": {
+					"description": "Veuillez entrer une description pour cette application."
+				}
+			},
+			"pages": {
+				"delete": {
+					"confirmationMessage": "Voulez-vous vraiment supprimer la page {{name}}?"
+				},
+				"hide": "Cacher la page dans la barre latérale de navigation",
+				"notReordered": {
+					"plural": "Les pages n'ont pas été réorganisées. {{error}}",
+					"singular": "La page n'a pas été réorganisée. {{error}}"
+				},
+				"reordered": {
+					"plural": "Les pages ont été réorganisées avec succès.",
+					"singular": "La page a été réorganisée avec succès."
+				},
+				"settings": {
+					"actions": "Actions",
+					"goNextStepOnSave": "Aller à l'étape suivante après avoir enregistré",
+					"selectIcon": "Sélectionnez une icône",
+					"tooltip": {
+						"autoSave": "Les modifications sont automatiquement enregistrées"
+					}
+				},
+				"show": "Afficher la page dans la barre latérale de navigation"
+			},
+			"positionAttribute": {
+				"delete": {
+					"confirmationMessage": "Voulez-vous vraiment supprimer l'attribut de position {{name}} ?",
+					"title": "Supprimer l'attribut de position"
+				}
+			},
+			"publish": {
+				"confirmationMessage": "Confirmer la publication de l'application {{name}} ?",
+				"title": "Publier l'application"
+			},
+			"subscription": {
+				"modal": {
+					"hint": {
+						"listenTo": "Clé de routage de l'agent de messages"
+					},
+					"listenTo": "Écouter",
+					"placeholder": {
+						"listenTo": "Sélectionner une clé de routage"
+					},
+					"routingKey": {
+						"clear": {
+							"ariaLabel": "Supprimer la clé de routage"
+						}
+					}
+				}
+			},
+			"unlock": {
+				"confirmationMessage": "Voulez-vous déverrouiller l'édition de {{name}} ?",
+				"title": "Déverrouiller l'édition"
+			},
+			"update": {
+				"hideMenu": "Cacher le menu vertical de navigation par défaut",
+				"placeholder": {
+					"description": "Veuillez entrer une description pour l'application."
+				},
+				"sideMenu": "Afficher le menu sur le côté",
+				"tooltip": {
+					"hideMenu": "Ne s'applique que lorsque le menu est sur le côté"
+				}
+			},
+			"users": {
+				"auto": "Attribution automatique",
+				"empty": "Aucun utilisateur détecté",
+				"manual": "Attribution manuelle"
+			}
+		},
+		"applications": {
+			"dropdown": {
+				"select": "Depuis les applications"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page d'applications"
+			}
+		},
+		"calculatedFields": {
+			"add": "Créer un nouveau champ dérivé",
+			"delete": {
+				"confirmationMessage": "Confirmez-vous la suppression du champ dérivé {{name}} ?"
+			},
+			"edit": "Modifier le champ dérivé",
+			"expression": "Expression",
+			"hint": {
+				"name": "Entrez un nom composé uniquement delettres, dechiffres et de tirets bas. Ce nom ne doit pas dupliquer le nom d'un autre champ de la resource éditée."
+			}
+		},
+		"channel": {
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer le canal {{name}} ?"
+			},
+			"dropdown": {
+				"select": "Notifier sur"
+			},
+			"selectChannel": "Sélectionnez un canal"
+		},
+		"confirmModal": {
+			"cancel": "Annuler",
+			"confirm": "Confirmer",
+			"delete": "Supprimer",
+			"title": "Confirmer"
+		},
+		"customNotifications": {
+			"edit": {
+				"dataset": "Jeu de données",
+				"email": "Notification par email",
+				"new": "Nouvelle notification",
+				"recipients": {
+					"distributionList": "Utiliser une liste de distribution",
+					"email": "Utiliser une adresse email unique",
+					"title": "Destinataires",
+					"userField": "Grouper par utilisateurs détectés dans les enregistrements"
+				},
+				"update": "Éditer la notification"
+			},
+			"errors": {
+				"email": "Veuillez entrer une adresse email valide",
+				"schedule": "Veuillez entrer une expression cron valide"
+			},
+			"hint": {
+				"schedule": "Indiquez une fréquence d'envoi"
+			}
+		},
+		"distributionLists": {
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer la liste de distribution: '{{name}}'?"
+			},
+			"edit": {
+				"name": "Nom de la liste de distribution",
+				"new": "Nouvelle liste de distribution",
+				"update": "Éditer la liste de distribution"
+			},
+			"errors": {
+				"emails": {
+					"pattern": "Veuillez uniquement fournir des emails valides",
+					"required": "Veuillez fournir un ou plusieurs emails"
+				},
+				"name": {
+					"required": "Veuillez fournir un nom"
+				}
+			}
+		},
+		"emailBuilder": {
+			"body": "Corps du texte",
+			"default": "Défaut",
+			"fields": "Sélectionner les champs à écrire dans le corps du texte",
+			"from": {
+				"distribution": "Liste de distribution",
+				"field": "Champ de données",
+				"title": "Depuis:"
+			},
+			"subject": "Objet",
+			"withoutRecords": "Sans enregistrements"
+		},
+		"emailPreview": {
+			"errors": {
+				"missingSubject": "L'objet du mail ne peut être vide."
+			},
+			"from": "De",
+			"subject": "Objet",
+			"title": "Prévisualisation de mail",
+			"to": "À"
+		},
+		"floating": {
+			"menuButton": {
+				"ariaLabel": "***"
+			}
+		},
+		"form": {
+			"aggregation": {
+				"delete": {
+					"confirmationMessage": "Confirmez-vous la suppression de l'agrégation {{name}}?"
+				}
+			},
+			"create": {
+				"choice": {
+					"inherit": "Copier un modèle de ressources existant",
+					"resource": "Créer une nouvelle ressource",
+					"template": "Commencer depuis un modèle existant"
+				},
+				"template": {
+					"from": "Depuis le modèle",
+					"placeholder": "Choisir un modèle existant",
+					"selectResource": "Sélectionnez une ressource",
+					"title": "Depuis la ressource"
+				},
+				"tooltip": {
+					"inherit": "Crée un formulaire hérité en utilisant comme modèle la ressource liée à un formulaire source.",
+					"resource": "Crée un formulaire source permettant la création de formulaire hérités liés à celui-ci. Crée aussi une nouvelle ressource liée.",
+					"template": "Si aucun modèle n'est sélectionné, la structure principale sera chargée"
+				}
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer le formulaire {{name}} ?"
+			},
+			"deleteRow": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer {{quantity}} {{rowText}}?"
+			},
+			"display": {
+				"submissionMessage": "Le formulaire a été sauvegardé."
+			},
+			"draftRecords": {
+				"buttonLoad": "Charger un brouillon",
+				"confirmModal": {
+					"confirmDelete": "Voulez-vous vraiment supprimer ce brouillon ?",
+					"confirmLoad": "Voulez-vous vraiment charger ce brouillon ?",
+					"delete": "Supprimer ce brouillon",
+					"load": "Charger ce brouillon"
+				},
+				"creationDate": "Date de création",
+				"delete": "Supprimer ce brouillon",
+				"load": "Charger ce brouillon",
+				"noDrafts": "Aucun enregistrement brouillon disponible",
+				"preview": "Prévisualiser ce brouillon",
+				"previewTitle": "Enregistrement brouillon",
+				"save": "Enregistrer comme brouillon",
+				"select": "Sélectionner le brouillon",
+				"successEdit": "Brouillon modifié avec succès",
+				"successSave": "Enregistré dans les brouillons avec succès"
+			},
+			"layout": {
+				"delete": {
+					"confirmationMessage": "Voulez-vous vraiment supprimer la mise en page {{name}} ?"
+				},
+				"errors": {
+					"invalid": "Le formulaire est invalide"
+				},
+				"update": {
+					"preview": {
+						"description": "Réorganise, trie, filtre et cache des colonnes pour changer l'affichage par défaut de la mise en page"
+					}
+				}
+			},
+			"searchExistingRecords": {
+				"matches": "Résultats",
+				"noMatches": "Aucun résultat",
+				"openRecordTooltip": "Ouvrir l'enregistrement"
+			},
+			"summary": {
+				"cache": {
+					"clear": "Vider le cache",
+					"load": "Charger depuis le cache {{date}}"
+				},
+				"createdBy": "Créé par {{user}} le {{date}}",
+				"modifiedBy": "Modifié pour la dernière fois par {{user}} le {{date}}"
+			},
+			"update": {
+				"exit": "Quitter sans sauvegarder les changements",
+				"exitMessage": "Il y a des changements non sauvegardés dans votre formulaire, voulez-vous vraiment quitter cette page ?"
+			},
+			"updateRow": {
+				"confirmationMessage": "Souhaitez-vous mettre à jour {{quantity}} {{rowText}}?"
+			}
+		},
+		"formBuilder": {
+			"errors": {
+				"duplicatedRelatedName": "Nom lié en double pour la question {{question}} à la page {{page}}. Veuillez fournir un nom lié unique (au format snake_case) pour sauvegarder le formulaire.",
+				"incorrectJSON": "Le JSON est invalide dans le JSON Editor, les changements n'ont pas été sauvegardés",
+				"missingGridField": "Champs disponible de table de données manquant pour la question {{question}} à la page {{page}}. Veuillez en sélectionner au moins un dans la propriété Custom Question pour sauvegarder le formulaire.",
+				"missingRelatedName": "Nom lié manquant pour la question {{question}} à la page {{page}}. Veuillez entrer un nom valide pour la valeur de la donnée (au format snake_case) pour sauvegarder le formulaire.",
+				"missingTemplate": "Ressource liée manquante pour la question {{question}} à la page {{page}}. Veuillez sélectionner un modèle pour sauvegarder le formulaire."
+			},
+			"propertyGrid": {
+				"resource": {
+					"availableGridFields": "Champs de grille disponibles",
+					"resourceSelectText": "Vous devez d’abord sélectionner une ressource avant de définir des filtres"
+				}
+			},
+			"saveSurvey": "Sauvegarde du questionnaire"
+		},
+		"formMapProperties": {
+			"geofields": {
+				"editDialog": {
+					"editGeofield": "Éditer les champs",
+					"label": "Label",
+					"value": "Valeur"
+				}
+			}
+		},
+		"forms": {
+			"isCore": "Est un formulaire source",
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page de formulaires"
+			},
+			"parent": "Formulaire parent"
+		},
+		"group": {
+			"add": {
+				"title": "Ajouter un nouveau groupe"
+			},
+			"delete": {
+				"confirmationMessage": "Confirmez-vous la suppression du groupe {{name}}?",
+				"title": "Supprimer le groupe"
+			}
+		},
+		"header": {
+			"goToApp": "Ouvrir l'application",
+			"goToPlatform": "Naviguer vers",
+			"logout": "Se déconnecter",
+			"sidenav": {
+				"collapse": "Cacher la barre latérale",
+				"show": "Afficher la barre latérale"
+			}
+		},
+		"history": {
+			"changes": {
+				"add": "Ajout",
+				"from": "de",
+				"modify": "Modification",
+				"remove": "Suppression",
+				"to": "à",
+				"withValue": "avec valeur"
+			},
+			"columns": {
+				"action": "Type d'action",
+				"date": "Date",
+				"modifiedValue": "Ancienne valeur",
+				"originalValue": "Nouvelle valeur",
+				"person": "Utilisateur",
+				"time": "Heure",
+				"variable": "Champ"
+			},
+			"download": "Télécharger l'historique",
+			"empty": "Aucune activité détectée",
+			"field": {
+				"all": "Tous les champs",
+				"select": "Sélectionner les champs"
+			},
+			"preview": "Prévisualiser et revenir",
+			"range": {
+				"clear": "Effacer la plage de données"
+			},
+			"useTableMode": "Afficher en table"
+		},
+		"icon": {
+			"modal": {
+				"select": "Sélectionner une icône",
+				"use": "Utiliser l'icône"
+			}
+		},
+		"logout": {
+			"confirmationMessage": "Le formulaire contient des éléments non sauvegardés. Voulez-vous vous vraiment déconnecter ?",
+			"title": "Quitter la plateforme sans sauvegarder"
+		},
+		"map": {
+			"controls": {
+				"download": {
+					"layers": {
+						"all": "Toutes les couches",
+						"selected": "Couches sélectionnées",
+						"visible": "Couches visibles"
+					},
+					"output": "Format d'export",
+					"selectLayers": "Sélectionnez les couches",
+					"view": {
+						"all": "Toute la carte",
+						"current": "Vue actuelle"
+					}
+				},
+				"timeline": {
+					"show": "Afficher la chronologie",
+					"time": {
+						"dateFormat": "Affichage des dates",
+						"startField": "Commencez à afficher à",
+						"stopField": "Arrêter de s'afficher à",
+						"tooltip": "Lorsqu'elle est activée, une chronologie sera affichée sur la carte. Il vous permettra de visualiser l’évolution de vos données dans le temps."
+					},
+					"title": "Timeline"
+				}
+			}
+		},
+		"mapping": {
+			"field": "Champ de l'utilisateur",
+			"path": "Chemin",
+			"text": "Texte",
+			"title": "Table de correspondances",
+			"value": "Valeur"
+		},
+		"notifications": {
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page de notifications"
+			},
+			"readAll": "Tout marquer comme lu",
+			"title": "Notifications"
+		},
+		"paginator": {
+			"items": "élements",
+			"itemsPerPage": "éléments par page",
+			"of": "de",
+			"page": "Page"
+		},
+		"preferences": {
+			"dateFormat": "Format de date et heure",
+			"language": "Langage",
+			"title": "Préférences"
+		},
+		"pullJob": {
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer la tâche {{name}} ?",
+				"title": "Supprimer la tâche"
+			},
+			"modal": {
+				"addMappingField": "ajouter un champ de correspondance",
+				"errors": {
+					"schedule": "Entrez une expression cron valide"
+				},
+				"hint": {
+					"path": "Entrer le chemin pour extraire la donnée de la réponse",
+					"schedule": "Entrez une expression CRON pour planifier la tâche",
+					"url": "Entrez l'URL après l'hôte pour atteindre la donnée spécifique"
+				},
+				"identifier": "Identificateurs uniques",
+				"mapping": "Correspondance",
+				"placeholder": {
+					"path": "Entrez le chemin d'accès...",
+					"schedule": "Entrez l'horaire planifié...",
+					"url": "Entrer l'URL..."
+				},
+				"switch": "Changer de mode"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionez la page de tâches programmées"
+			}
+		},
+		"queryBuilder": {
+			"dataset": {
+				"select": "Sélectionner un jeu de données"
+			},
+			"errors": {
+				"field": {
+					"invalid": "Champ invalide. Veuillez cliquer pour le retirer."
+				}
+			},
+			"fields": {
+				"available": "Champs disponibles",
+				"column": "Largeur de la colonne (px)",
+				"format": {
+					"info": "Laissez vide pour utiliser le mode classique",
+					"title": "Mode d'affichage"
+				},
+				"search": "Rechercher des champs...",
+				"selected": "Champs sélectionnés",
+				"title": "Champs"
+			},
+			"filter": {
+				"and": "Et",
+				"logic": "Logique de filtre",
+				"new": "Ajouter un nouveau filtre",
+				"newGroup": "Ajouter un nouveau groupe de filtres",
+				"operator": "Opérateur",
+				"or": "Ou",
+				"title": "Filtre"
+			},
+			"hint": {
+				"fields": "Sélectionnez des champs ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite",
+				"sortingDisabled": "Le tri est désactivé quand la recherche est active.",
+				"style": "Les règles de style font ressortir les enregistrements contenant des informations importantes. Quand un enregistrement vérifie plusieurs règles, la première est utilisée."
+			},
+			"pagination": {
+				"first": "Limite",
+				"title": "Pagination"
+			},
+			"sort": {
+				"ascending": "Croissant",
+				"descending": "Décroissant",
+				"field": "Filtrer le champ",
+				"limit": "limite",
+				"limitTitle": "Tri et limite",
+				"order": "Ordre de tri",
+				"title": "Tri"
+			},
+			"style": {
+				"and": "Et",
+				"edit": {
+					"appliesTo": "Appliquer le style à",
+					"background": {
+						"color": "Couleur de fond"
+					},
+					"criteria": "Critère",
+					"fields": "Champ",
+					"name": "Nom de la règle",
+					"selectedColumns": "Seulement les colonnes sélectionnées.",
+					"text": {
+						"color": "Couleur du texte",
+						"style": "Style du texte"
+					},
+					"wholeRow": "Ligne entière"
+				},
+				"logic": "Filtre de style",
+				"new": "Ajouter une règle de style",
+				"operator": "Opérateur",
+				"or": "Ou",
+				"title": "Style"
+			},
+			"tooltip": {
+				"filter": {
+					"date": {
+						"useExpression": "Utiliser une expression",
+						"usePicker": "Choisir une date"
+					}
+				},
+				"pagination": {
+					"first": "Limite le nombre d'éléments renvoyés"
+				}
+			}
+		},
+		"record": {
+			"attach": {
+				"confirm": "Attacher",
+				"selectTarget": "Sélectionner la cible {{name}}"
+			},
+			"convert": {
+				"choice": {
+					"copy": "Copier l'enregistrement source",
+					"overwrite": "Écraser l'enregistrement source"
+				},
+				"result": {
+					"force": "Les champs suivants seront ignorés :",
+					"smooth": "Conversion OK"
+				},
+				"select": "Convertir en"
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer l'enregistrement {{name}} ?",
+				"permanently": "Supprimer de manière permanente"
+			},
+			"dropdown": {
+				"select": "Sélectionner un enregistrement"
+			},
+			"history": {
+				"revert": "Revenir à l'enregistrement précédent",
+				"version": {
+					"current": "Version actuelle",
+					"old": "Ancienne version"
+				}
+			},
+			"modal": {
+				"closeConfirmation": "Fermer sans enregistrer les modifications ?",
+				"update": "Sauvegarder et fermer"
+			},
+			"recovery": {
+				"confirmationMessage": "Souhaitez-vous appliquer les données du {{date}} à l'enregistrement ?",
+				"title": "Récupération de données"
+			}
+		},
+		"records": {
+			"active": "Enregistrements actifs",
+			"archived": "Enregistrements archivés",
+			"editAs": "Editer en tant que",
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page d'enregistrements"
+			},
+			"showActive": "Voir les enregistrements actifs",
+			"showArchived": "Voir les enregistrements archivés",
+			"upload": {
+				"hint": "Le fichier doit contenir uniquement un enregistrement par ligne. La ligne d'en-tête contient les noms des champs de données."
+			}
+		},
+		"referenceData": {
+			"create": {
+				"title": "Nouvelle référence de données"
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer la référence de données {{name}} ?",
+				"title": "Supprimer la référence de données"
+			},
+			"dropdown": {
+				"select": "Depuis la référence de données"
+			},
+			"fields": {
+				"add": "Ajouter le champ",
+				"ariaLabel": "Indiquez les champs de la référence de données",
+				"new": "Nouveau champ"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page de références de données"
+			}
+		},
+		"resource": {
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer la ressource {{name}} ?"
+			},
+			"dropdown": {
+				"select": "Depuis la ressource"
+			},
+			"empty": {
+				"aggregations": "Aucune agrégation détectée",
+				"calculatedFields": "Aucun champ dérivé détecté",
+				"layouts": "Aucune mise en page détectée",
+				"records": "Aucun enregistrement détecté"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page de ressources"
+			}
+		},
+		"role": {
+			"add": {
+				"title": "Ajouter un nouveau rôle"
+			},
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer le rôle {{name}} ?",
+				"title": "Supprimer le rôle"
+			},
+			"impersonate": {
+				"title": "Choix du rôle à simuler"
+			},
+			"summary": {
+				"addFilter": "Ajouter un filtre",
+				"autoAssignment": {
+					"rule": {
+						"add": "Ajouter une règle d'attribution",
+						"delete": "Supprimer la règle",
+						"edit": "Mettre à jour la règle d'attribution",
+						"none": "Aucune règle d'attribution automatique",
+						"title": "Règle"
+					},
+					"title": "Attribution automatique"
+				},
+				"details": {
+					"access": {
+						"channels": "Canaux accessibles",
+						"fullAccess": "Accès complet à {{accessible}} / {{total}}",
+						"limitedAccess": "Accès limité à {{accessible}} / {{total}}",
+						"noAccess": "Pas d'accès à {{accessible}} / {{total}}",
+						"pages": "Pages accessibles",
+						"resources": "Ressources accessibles",
+						"title": "Accès"
+					}
+				},
+				"editFilters": "Modifier les filtres",
+				"features": "Fonctionnalités",
+				"newFilter": "Nouveau filtre",
+				"noFeatures": "Aucune fonctionnalité détectée",
+				"noFilters": "Aucun filtre d'accès détecté",
+				"noForms": "Aucun formulaire détecté",
+				"noSteps": "Aucune étape détectée",
+				"removeFilter": "Supprimer le filtre",
+				"title": "Résumé",
+				"users": {
+					"auto": "Attribution automatique",
+					"empty": "Aucun utilisateur détecté",
+					"manual": "Attribution manuelle"
+				}
+			},
+			"tooltip": {
+				"allowFieldAccessibility": "Autoriser ce rôle à voir le champ {{field}}",
+				"allowFieldUpdate": "Autoriser ce rôle à mettre à jour le champ {{field}}",
+				"disallowFieldAccessibility": "Interdire ce rôle pour voir le champ {{field}}",
+				"disallowFieldUpdate": "Interdire ce rôle pour mettre à jour le champ {{field}}",
+				"grantAddRecordsPermission": "Permet de créer de nouveaux enregistrements",
+				"grantDeleteRecordsPermission": "Permet de supprimer tous les enregistrements",
+				"grantFilterDeleteRecordsPermission": "Permet de supprimer les enregistremetns satisfaisant le filtre",
+				"grantFilterReadRecordsPermission": "Permet de voir les enregistrements satisfaisant le filtre",
+				"grantFilterUpdateRecordsPermission": "Permet de mettre à jour les enregistrements satisfaisant le filtre",
+				"grantReadRecordsPermission": "Permet de voir tous les enregistrements",
+				"grantUpdateRecordsPermission": "Permet de mettre à jour tous les enregistrements",
+				"hideFeature": "Masquer {{page}} pour ce rôle",
+				"limitedDeleteRecordsPermission": "Permet de supprimer les enregistrements satisfaisant les filtres",
+				"limitedReadRecordsPermission": "Permet de voir les enregistrements satisfaisant les filtres",
+				"limitedUpdateRecordsPermission": "Permet de mettre à jour les enregistrements satisfaisant les filtres",
+				"notGrantAddRecordsPermission": "Ne donne pas la permission d'ajouter de nouveaux enregistrements",
+				"notGrantDeleteRecordsPermission": "Ne donne pas la permission de supprimer les enregistrements",
+				"notGrantFilterDeleteRecordsPermission": "Ne donne pas la permission de supprimer les enregistrements satisfaisant le filtre",
+				"notGrantFilterReadRecordsPermission": "Ne donne pas la permission de voir les enregistrements satisfaisant le filtre",
+				"notGrantFilterUpdateRecordsPermission": "Ne donne pas la permission de mettre à jour les enregistrements satisfaisant le filtre",
+				"notGrantReadRecordsPermission": "Ne donne pas la permission de voir les enregistrements",
+				"notGrantUpdateRecordsPermission": "Ne donne pas la permission de mettre à jour les enregistrements",
+				"showFeature": "Afficher {{page}} pour ce rôle"
+			},
+			"update": {
+				"permissions": "Permissions",
+				"title": "Modifier les permissions des rôles et les canaux de diffusion"
+			}
+		},
+		"share": {
+			"modal": {
+				"copy": "Copier dans le presse-papiers",
+				"title": "Partager l'url du dashboard"
+			}
+		},
+		"templates": {
+			"available": "Modèles d'email disponibles",
+			"delete": {
+				"confirmationMessage": "Voulez-vous supprimer le modèle '{{name}}'?",
+				"titleMessage": "Supprimer le modèle"
+			},
+			"edit": {
+				"body": "Corps du texte",
+				"name": "Nom du modèle de notification",
+				"new": "Nouveau modèle de notification",
+				"subject": "Sujet",
+				"update": "Éditer le modèle de notification"
+			},
+			"errors": {
+				"empty": "Veuillez sélectionner au moins un modèle"
+			},
+			"select": {
+				"email": "Sélectionnez un modèle d'e-mail"
+			},
+			"type": {
+				"email": "E-mail",
+				"title": "Type de modèle"
+			}
+		},
+		"user": {
+			"delete": {
+				"confirmationMessage": "Voulez-vous vraiment supprimer l'utilisateur {{name}} ?",
+				"title": "Supprimer l'utilisateur"
+			},
+			"invite": {
+				"confirm": "Inviter",
+				"role": {
+					"additionalAttributes": "Définir des attributs supplémentaires",
+					"description": "Sélectionner le rôle à assigner"
+				}
+			},
+			"summary": {
+				"country": "Pays",
+				"firstName": "Prénom",
+				"lastName": "Nom",
+				"locationType": "Type de localisation",
+				"region": "Région",
+				"roles": {
+					"application": "Rôles d'application",
+					"backoffice": "Rôles de back-office",
+					"selectedApplication": "Application sélectionnée",
+					"selectedGroups": "Groupes sélectionnés",
+					"selectedRoles": "Rôles sélectionnés"
+				},
+				"title": "Résumé"
+			},
+			"update": {
+				"title": "Modifier l'utilisateur"
+			}
+		},
+		"users": {
+			"invite": {
+				"add": "Ajouter un nouvel utilisateur",
+				"confirm": "Inviter des utilisateurs",
+				"description": "Sélectionner des utilisateurs existants, inviter de nouveaux utilisateurs ou en importer depuis un fichier Excel"
+			},
+			"onDelete": {
+				"plural": "Les utilisateurs ont été correctement supprimés.",
+				"singular": "L'utilisateur a été correctement supprimé."
+			},
+			"onInvite": {
+				"plural": "Les utilisateurs ont été invités.",
+				"singular": "L'utilisateur a été invité."
+			},
+			"onNotDelete": {
+				"plural": "Les utilisateurs n'ont pas été supprimés. {{error}}",
+				"singular": "L'utilisateur a été supprimé. {{error}}"
+			},
+			"onNotInvite": {
+				"plural": "Les utilisateurs n'ont pas été invités. {{error}}",
+				"singular": "L'utilisateur n'a pas été invité. {{error}}"
+			},
+			"paginator": {
+				"ariaLabel": "Sélectionnez la page d'utilisateurs"
+			}
+		},
+		"widget": {
+			"chart": {
+				"errors": {
+					"aggregation": {
+						"invalid": "Agrégation invalide"
+					}
+				},
+				"filters": {
+					"select": "Sélectionnez un filtre..."
+				},
+				"other": "Autre"
+			},
+			"display": {
+				"tooltip": {
+					"placeholder": "Entrez une valeur pour l'info-bulle"
+				}
+			},
+			"expand": "Étendre",
+			"grid": {
+				"actions": {
+					"detail": "Ouvrir le détail",
+					"downloadReport": "Télécharger",
+					"goTo": "Aller à la page",
+					"history": "Voir l'historique"
+				},
+				"empty": "Aucun enregistrement détecté pour cette configuration de réseau",
+				"errors": {
+					"autoSaveFailed": "L'exécution de l'action a été stoppé à cause d'enregistrement(s) non valide(s). Veuillez les vérifier avant de lancer une autre action.",
+					"invalid": {
+						"backoffice": "Configuration de grille invalide",
+						"frontoffice": "Configuration de grille non valide, veuillez contacter votre administrateur",
+						"widgets": "Configuration de grille non valide, veuillez contacter votre administrateur"
+					},
+					"metaQueryBuildFailed": "Erreur lors de la création des métadonnées",
+					"metaQueryFetchFailed": "Erreur lors de la récupération des métadonnées: {{error}}",
+					"missingDataset": "Sélectionner un jeu de données dans les jeux de données",
+					"noRowsSelected": "Aucune ligne sélectionnée",
+					"queryBuildFailed": "Erreur lors de la création de la requête",
+					"queryFetchFailed": "Erreur lors de la récupération des données : {{error}}",
+					"validationFailed": "Les enregistrements suivants n'ont pas pu être sauvegardés car invalides :\n{{errors}}\nMerci de les modifier en utilisant le bouton \"Mettre à jour \" pour plus de détails."
+				},
+				"export": {
+					"columns": {
+						"choice": {
+							"all": "Toutes les colonnes disponibles",
+							"visible": "Toutes les colonnes visibles"
+						},
+						"title": "Sélectionner les colonnes à exporter"
+					},
+					"dataset": {
+						"choice": {
+							"all": "Tous les enregistrements visibles",
+							"selected": "Seulement les enregistrements visibles"
+						},
+						"title": "Sélectionner les enregistrements à exporter"
+					},
+					"email": {
+						"title": "M'envoyer le fichier par e-mail",
+						"tooltip": "Si sélectionné, vous recevrez le fichier par e-mail, au lieu d'attendre son téléchargement ici."
+					},
+					"format": {
+						"title": "Sélectionner le format d'export"
+					}
+				},
+				"filter": {
+					"toggle": "Activer la visibilité du filtre"
+				},
+				"item": {
+					"few": "{{count}} éléments",
+					"none": "Aucun élément",
+					"one": "{{count}} élément"
+				},
+				"layout": {
+					"button": {
+						"title": "Cela effacera la mise en page actuelle avec la mise en page par défaut"
+					},
+					"reset": "Réinitialiser la mise en page par défaut"
+				},
+				"loading": {
+					"records": "Chargement des enregistrements...",
+					"settings": "Chargement des paramètres..."
+				},
+				"map": {
+					"mapDetailsTitle": "Cartographie des données",
+					"mapDetailsTooltip": "Centré par defaut sur l'enregistrement sélectionné"
+				},
+				"openSettings": "Ouvrir les paramètres",
+				"tooltip": {
+					"displayMap": "Afficher la carte",
+					"openPage": "Aller à la page",
+					"saved": "Changements sauvegardés",
+					"unsaved": "Cliquez sur sauvegarder pour enregistrer les changements",
+					"uploadFailed": "L'enregistrement a échoué. Cliquez pour obtenir plus de détails"
+				},
+				"validation": {
+					"help": "Veuillez modifier l'enregistrement à l'aide du bouton \"Mettre à jour\".",
+					"questionTitle": "Erreurs sur le champ {{question}}:",
+					"subtitle": "Ces erreurs furent détectées durant l'enregistrement :",
+					"title": "L'enregistrement du document {{record}} a échoué"
+				}
+			},
+			"settings": {
+				"chart": {
+					"auto": "auto",
+					"axes": "Axes",
+					"categories": "Catégories",
+					"color": "Couleur",
+					"filters": {
+						"add": "Ajouter un filtre",
+						"delete": "Supprimer le filtre",
+						"empty": "Aucun filtre configuré",
+						"title": "Filtres prédéfinis"
+					},
+					"grid": {
+						"buttons": {
+							"modifySelectedRows": {
+								"confirmation": "Voulez-vous vraiment modifier les lignes sélectionnées?"
+							}
+						},
+						"title": "Grille",
+						"x": {
+							"display": "Afficher les lignes horizontales"
+						},
+						"y": {
+							"display": "Afficher les lignes verticales"
+						}
+					},
+					"hideLegend": "Masquer la légende",
+					"labels": {
+						"percentage": "Pourcentage",
+						"showCategory": "Afficher la catégorie",
+						"showValue": "Afficher la valeur",
+						"title": "Labels",
+						"valueType": "Type de valeur"
+					},
+					"legend": "Légende",
+					"orientation": "Orientation",
+					"other": "Autre",
+					"palette": {
+						"enable": "Configurer la palette",
+						"title": "Palette de couleurs"
+					},
+					"position": "Position",
+					"series": {
+						"fill": "Remplissage",
+						"interpolation": {
+							"step": "Étape d'interpolation",
+							"title": "Interpolation"
+						},
+						"showSeries": "Afficher la serie",
+						"stack": {
+							"enable": "Empiler les séries",
+							"usePercentage": "Utiliser des pourcentages"
+						},
+						"title": "Séries"
+					},
+					"size": "Taille",
+					"stepSize": "Intervalle entre les marques",
+					"style": "Style",
+					"text": "Texte",
+					"title": {
+						"color": "Couleur",
+						"format": "Format"
+					},
+					"tooltip": {
+						"palette": "Les couleurs de la palette sont appliquées par défaut aux éléments du graphqiue, mais peuvent être manuellement changées pour chaque série et catégorie.",
+						"stepSize": "Intervalle entre chaque marque de graduation sur l'axe, lorsque possible"
+					},
+					"type": "Graphique",
+					"xAxis": "Axe X",
+					"yAxis": "Axe Y"
+				},
+				"close": {
+					"confirmationMessage": "Vos changements vont être perdus si vous fermez la fenêtre d'édition. Voulez-vous continuer ?"
+				},
+				"editor": {
+					"recordSelection": "Sélection d'enregistrement",
+					"title": "Éditeur"
+				},
+				"grid": {
+					"actions": {
+						"add": "Ajouter de nouveaux enregistrements",
+						"convert": "Convertir des enregistrements",
+						"delete": "Supprimer les enregistrements",
+						"export": "Exporter les enregistrements",
+						"goTo": {
+							"column": {
+								"label": "Nom de la colonne",
+								"placeholder": "Entrez un nom pour la colonne..."
+							},
+							"field": {
+								"label": "Passer le champ comme paramètre de requête",
+								"placeholder": "Sélectionnez un champ"
+							},
+							"label": "Accédez à la page",
+							"target": {
+								"label": "Naviguez vers la page",
+								"placeholder": "Sélectionnez une page"
+							}
+						},
+						"inline": "Modifier par ligne",
+						"navigateToPage": "Accédez à la page",
+						"pageUrl": {
+							"label": "Url de la source de la page",
+							"placeholder": "Entrez l'id de la page"
+						},
+						"pageUrlTitle": {
+							"label": "Nom de la colonne",
+							"placeholder": "Entrez un nom pour la colonne..."
+						},
+						"remove": "Retirer",
+						"show": "Voir l'historique",
+						"showDetails": "Afficher les détails des enregistrements",
+						"title": "Actions activées",
+						"update": "Modifier les enregistrements",
+						"useRecordId": "Injecter l'identifiant comme paramètre de navigation"
+					},
+					"aggregations": {
+						"add": {
+							"choice": {
+								"create": "Créer une nouvelle agrégation"
+							}
+						},
+						"title": "Aggrégations"
+					},
+					"buttons": {
+						"callback": {
+							"attach": "Attacher à l'enregistrement",
+							"displayField": "Afficher le champ",
+							"export": "Exporter le jeu de données sélectionné",
+							"modify": "Modifier automatiquement les lignes sélectionnées",
+							"modifyField": "Champ à modifier",
+							"modifyValue": "Value to attribute",
+							"notify": {
+								"message": "Message de notification"
+							},
+							"prefill": "Préremplir le formulaire avec les données sélectionnées",
+							"save": "Sauvegarder automatiquement",
+							"selectAllRecords": "Sélectionner tous les enregistrements",
+							"selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
+							"selectDisplay": "Sélectionner les champs affichés",
+							"sendMail": "Envoyer le mail",
+							"workflow": {
+								"close": "Fermer le workflow",
+								"confirm": "Message de confirmation",
+								"next": "Aller à l'étape suivante",
+								"previous": "Aller à l'étape précédente"
+							}
+						},
+						"create": "Ajouter un bouton",
+						"defaultName": "Bouton d'action",
+						"enable": "Activer",
+						"placeholder": {
+							"modifyValue": "Supprimer la valeur"
+						},
+						"requireConfirmation": "Exiger une confirmation",
+						"title": "Bouton d'action rapide",
+						"tooltip": {
+							"attach": "Si activé, vous devez fournir un formulaire et un champ dans ce formulaire. Toutes les lignes sélectionnées seront attachées à un enregistrement de ce formulaire. L'utilisateur pourra choisir cet enregistrement grâce au champ donné.",
+							"mail": {
+								"selectDistributionList": "Sélectionnez la liste de distribution qui fournira les destinataires de l'email",
+								"selectTemplates": "Sélectionnez les modèles d'email que les utilisateurs pourront choisir en utilisant l'action"
+							},
+							"notify": "Si activé, vous devez fournir un canal de diffusion et un message.Toutes les lignes sélectionnées seront envoyées en tant que notification unique sur le canal spécifié. Le message fourni est utilisé pour définir l'action de la notification.",
+							"publish": "Si activé, vous devez fournir un canal de diffusion. Toutes les lignes sélectionnées seront envoyées en tant que notification unique sur le canal spécifié. Quiconque écoutant sur ce canal pourra recevoir ces enregistrements."
+						}
+					},
+					"display": {
+						"actionsTitle": "Afficher le titre des actions",
+						"injectClasses": {
+							"title": "Injecter des valeurs en tant que classes CSS",
+							"tooltip": "Lorsqu'un champ est sélectionné, sa valeur sera ajoutée à l'élément <tr> en tant que classe, lui permettant d'être ciblé par un style personnalisé"
+						},
+						"showSingleActionAsButton": "Afficher une seule action sous forme de bouton"
+					},
+					"hint": {
+						"actions": {
+							"add": "L'utilisateur peut ajouter de nouveaux enregistrements avec le modèle choisi, s'il en a la permission",
+							"convert": "L'utilisateur peut convertir les enregistrements avec les autres modèles de la ressource sélectionnée, s'il en a la permission",
+							"delete": "L'utilisateur peut supprimer les enregistrements affichés, s'il en a la permission",
+							"export": "L'utilisateur peut exporter les enregistrements affichés",
+							"goTo": "L'utilisateur peut accéder au tableau de bord d'enregistrement",
+							"inline": "L'utilisateur peut éditer dans la grille les enregistrements affichés, s'il en a la permission",
+							"navigateToPage": "L'utilisateur peut accéder au tableau de bord d'enregistrement",
+							"show": "L'utilisateur peut afficher l'historique complet des enregistrements affichés",
+							"showDetails": "L'utilisateur peut afficher les informations des enregistrements affichés",
+							"update": "L'utilisateur peut mettre à jour les enregistrements affichés"
+						},
+						"attachToRecord": "Si les enregistrements sélectionnés ne sont joints à aucun enregistrement, l'action sera annulée",
+						"buttons": "Les boutons d'action rapides apparaîtront dans le widget et vous permettront de réaliser chacune des actions ci-dessous",
+						"executionOrder": "Les actions seront exécutées dans l'ordre affiché",
+						"prefillForm": "Si aucun enregistrement n'est créé à cette étape, l'action sera annulée"
+					},
+					"layouts": {
+						"add": {
+							"choice": {
+								"create": "Créer une nouvelle mise en page",
+								"load": "Charger une mise en page existante"
+							},
+							"title": "Ajouter une nouvelle mise en page"
+						},
+						"edit": {
+							"title": "Configuration de la mise en page"
+						},
+						"select": "Sélectionner une mise en page",
+						"title": "Mise en page de la grille"
+					},
+					"tooltip": {
+						"template": "Sélectionnez un modèle à utiliser pour l'ajout et l'édition des enregistrements",
+						"useRecordId": "L'url de redirection contiendra l'identifiant de l'élément, afin de naviguer à une page contextuelle, si configurée"
+					},
+					"warnings": {
+						"add": "Veuillez sélectionner un modèle",
+						"general": "Attention: les actions contiennent des erreurs"
+					}
+				},
+				"iconPicker": {
+					"default": "Standard",
+					"placeholder": "Chezchez un symbole"
+				},
+				"map": {
+					"basemap": "Fond de carte",
+					"category": "Catégories rapides",
+					"dataset": "Sélection du jeu de données",
+					"edit": {
+						"aggregation": "Agrégation",
+						"cluster": {
+							"autoSizeCluster": "Taille automatique des clusters",
+							"cluster": "Cluster",
+							"clusterSettings": "Paramètres de groupes",
+							"clustering": "Clustering",
+							"fields": "Champs de groupes",
+							"font": "Police",
+							"fontSize": "Taille de la police",
+							"high": "Haut",
+							"label": "Libellé du groupes",
+							"lightMode": "Mode lumineux",
+							"low": "Faible",
+							"max": "Max",
+							"min": "Min",
+							"overrideSymbol": "Remplacer le symbole de groupes",
+							"popups": "Groupes pop-ups",
+							"radius": "Rayon de groupes",
+							"sizeRange": "Gamme de taille",
+							"symbol": "Style de symboles"
+						},
+						"datasource": {
+							"origin": "Origine"
+						},
+						"fields": "Champs",
+						"filter": "Filtre",
+						"groupLayers": "Regrouper les calques",
+						"labels": "Étiquettes",
+						"layerDatasource": "Source de données de la couche",
+						"layerEdition": "Edition de couche",
+						"layerProperties": "Propriétés",
+						"layerStyling": "Styles",
+						"popup": "Popup",
+						"properties": {
+							"defaultVisibility": "Visible par défaut",
+							"from": "de zoom ",
+							"opacity": "Opacité",
+							"to": " à zoom",
+							"visibilityRange": "Plage de visibilité",
+							"zoom": "Zoom"
+						},
+						"reduction": {
+							"noReduction": "Pas de réduction",
+							"reduction": "Réduction"
+						},
+						"style": {
+							"color": "Couleur",
+							"fieldForSize": "Taille basée sur le champ",
+							"icon": "Symbole",
+							"size": "Taille",
+							"stylingType": "Style de {{layerType}}"
+						},
+						"styling": {
+							"heatmapOptions": {
+								"blur": "Flou",
+								"gradient": "Gradient",
+								"minOpacity": "Opacité minimum",
+								"radius": "Rayon"
+							}
+						}
+					},
+					"errors": {
+						"latitude": "Latitude incorrecte, merci de sélectionner un nombre entre -90 et 90",
+						"longitude": "Longitude incorrecte, merci de sélectionner un nombre entre -180 et 180"
+					},
+					"geospatial": {
+						"layersStyles": {
+							"fill": {
+								"color": "Couleur du remplissage",
+								"opacity": "Opacité du remplissage",
+								"title": "Remplissage"
+							},
+							"marker": {
+								"color": "Couleur du marqueur",
+								"opacity": "Opacité du marqueur",
+								"title": "Marqueur"
+							},
+							"outline": {
+								"color": "Couleur du contour",
+								"opacity": "Opacité du contour",
+								"title": "Contour",
+								"width": "Largeur du contour"
+							},
+							"title": "Styles de calque"
+						}
+					},
+					"layers": {
+						"add": "Ajouter un nouveau calque",
+						"chooseLayer": "Choisir un calque existant",
+						"createGroup": "Créer un nouveau groupe de couches",
+						"createLayer": "Créer un nouveau calque",
+						"dataSource": {
+							"fieldMapping": "Mapping des Champs",
+							"geoField": "GeoField",
+							"latitude": "Latitude",
+							"longitude": "Longitude"
+						},
+						"edit": "Mettre à jour le calque {{name}}",
+						"online": {
+							"info": "Charger des couches depuis arcGIS online",
+							"select": "Chercher des couches",
+							"selected": "Couches sélectionnées",
+							"title": "Couches en ligne"
+						},
+						"point": {
+							"addNew": "Ajouter une nouvelle règle",
+							"category": "Couches rapides",
+							"color": "Couleur",
+							"info": "Afficher des marqueurs sur la carte pour chaque enregistrement, en indiquant les champs de géolocation de la source de données",
+							"rules": "Règles de marquarge",
+							"rulesInfo": "Configurer la taille et la couleur des marqueurs",
+							"size": "Taille",
+							"title": "Marqueurs"
+						},
+						"popup": {
+							"addField": "Ajouter un champ",
+							"description": "Description",
+							"fields": "Champs",
+							"fieldsElements": {
+								"description": "Description",
+								"title": "Titre"
+							},
+							"popup": "Popup",
+							"popupElements": "Éléments de popup",
+							"text": "Texte",
+							"title": "Titre",
+							"tooltip": {
+								"text": "Tapez '{' pour utiliser les champs de la source de données"
+							}
+						},
+						"remove": "Supprimer le calque",
+						"selectLayer": "Sélectionner un calque",
+						"styling": {
+							"style": "Style"
+						},
+						"types": {
+							"cluster": "Groupes",
+							"heatmap": "Carte de chaleur",
+							"point": "Point",
+							"polygon": "Polygone"
+						}
+					},
+					"legend": {
+						"high": "Haut",
+						"low": "Faible",
+						"title": "Légende"
+					},
+					"popup": {
+						"label": "Champs affichés dans le popup",
+						"location": "Emplacement",
+						"of": "{{current}} sur {{total}}",
+						"zoomTo": "Zoomer sur"
+					},
+					"properties": {
+						"basemap": "Fond de carte",
+						"controls": {
+							"download": "Télécharger",
+							"lastUpdate": "Dernière mise à jour le",
+							"lastUpdateError": "L'heure de la dernière modification n'a pas pu être chargée",
+							"lastUpdatePosition": "Choisissez une position pour afficher l'élément",
+							"layer": "Couches",
+							"legend": "Légende",
+							"measure": "Mesure",
+							"search": "Recherche",
+							"timedimension": "Dimension temporelle",
+							"title": "Contrôles de la carte"
+						},
+						"geographicExtent": "Type d'étendue",
+						"geographicExtentValue": "Valeur de l'étendue",
+						"latitude": "Latitude du centre de la carte",
+						"longitude": "Longitude du centre de la carte",
+						"setByMap": "Utiliser la vue actuelle",
+						"title": "Affichage par défaut",
+						"webmap": "WebMap",
+						"zoom": "Zoom par défaut"
+					},
+					"renderer": {
+						"default": "Défaut",
+						"defaultLabel": "Libellé par défaut",
+						"label": "Libellé",
+						"symbol": "Symbole",
+						"uniqueValue": "Valeurs uniques",
+						"value": "Valeur"
+					},
+					"tooltip": {
+						"category": "Sélectionnez un champ pour séparer vos enregistrements en différentes catégories",
+						"cluster": {
+							"autoSize": "La taille des clusters est automatique si activé, sinon, vous pouvez la définir.",
+							"lightMode": "Le texte s'affichera en blanc si activé, sinon en noir."
+						},
+						"dataset": "Sélectionnez des champs ci-dessous et déplacez-les vers 'champs sélectionnés' sur la droite. Ils seront présents dans le pop-up affiché en cliquant sur les marqueurs",
+						"default": {
+							"latitude": "Définissez la latitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la latitude de la carte d'aperçu.",
+							"longitude": "Définissez la longitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la longitude de la carte d'aperçu.",
+							"zoom": "Sélectionnez un zoom par défaut"
+						},
+						"geographicExtent": "Vous pouvez entrer une valeur statique, ou utiliser les notations {{context}} ou {{filter}} pour injecter la valeur"
+					}
+				},
+				"style": {
+					"customStyling": "Style personnalisé"
+				},
+				"summaryCard": {
+					"add": "Ajouter un carte",
+					"card": {
+						"dataSource": {
+							"layoutStyles": {
+								"queryFilters": {
+									"help": "N'oubliez pas de supprimer les variables non utilisées.",
+									"noVariables": "Aucune variable définie",
+									"refresh": "Afficher toutes les variables graphQL",
+									"title": "Mappage de variables GraphQL",
+									"tooltip": "Définissez les valeurs des variables GraphQL définies dans la requête de données de référence. Vous pouvez obtenir les valeurs des filtres à l'aide des modèles {{filter.<question-name>}}. Par exemple : { \"region\": {{filter.region}} }"
+								},
+								"title": "Styles de mise en page",
+								"use": "Utiliser les styles de mise en page",
+								"wholeRow": {
+									"option1": "Appliquer à tous les champs",
+									"option2": "Appliquer sur toute la carte",
+									"title": "Styles de lignes entières :"
+								}
+							},
+							"title": "Source de données"
+						},
+						"display": {
+							"dataSource": "Afficher le lien vers la source de données",
+							"header": "Titre",
+							"padding": "Utiliser la marge intérieure",
+							"title": "Affichage de la carte",
+							"tooltip": {
+								"datasource": "Ajoute un bouton pour afficher la source de données de la carte"
+							}
+						},
+						"gridActions": {
+							"title": "Actions de grille",
+							"tooltip": "Actions de grille activées"
+						},
+						"preview": {
+							"title": "Prévisualisation"
+						},
+						"textEditor": {
+							"alert": "Vous pouvez ajouter des variables ex: {{data.variable}} et faire des calculs ex: {{calc.round( value ; precision )}}",
+							"title": "Éditeur de texte"
+						},
+						"title": "Paramètres de carte",
+						"valueSelector": {
+							"title": "Selection de valeur"
+						}
+					},
+					"create": {
+						"choice": {
+							"blank": "Créer une nouvelle carte",
+							"template": "Utiliser un modèle"
+						}
+					},
+					"dynamic": "Dynamique",
+					"exportable": "Autoriser l'export des cartes",
+					"gridMode": "Peut être affiché en grille",
+					"hint": {
+						"dynamic": "Les cartes dynamiques adaptent leur affichage en fonction du nombre d'éléments dans la source de données. Vous devez définir une unique carte qui sera répétée pour chaque élément."
+					},
+					"loadMore": {
+						"infiniteScroll": "Utiliser le défilement infini",
+						"pagination": "Utiliser la pagination",
+						"title": "Déclencheur pour charger plus de données"
+					},
+					"options": {
+						"ariaLabel": "***"
+					},
+					"static": "Statique"
+				},
+				"tabs": {
+					"addNewTab": "Ajouter un nouvel onglet",
+					"deleteTab": "Supprimer l'onglet"
+				}
+			},
+			"styling": "Modifier le style",
+			"summaryCard": {
+				"dataSource": "Source",
+				"errors": {
+					"invalidSource": "La source de données est invalide : veuillez modifier les paramètres."
+				},
+				"viewAsCards": "Afficher en cartes",
+				"viewAsGrid": "Afficher en grille"
+			},
+			"text": {
+				"aggregations": {
+					"alert": "Vous pouvez créer des agrégations personnalisées et les injecter dans l'éditeur à l'aide d'espaces réservés {{aggregation.<id>}}.",
+					"template": {
+						"add": "Ajouter une nouvelle agrégation de modèles",
+						"edit": "Modifier l'agrégation de modèles"
+					}
+				}
+			}
+		}
+	},
+	"kendo": {
+		"combobox": {
+			"clearTitle": "Supprimer la valeur",
+			"noDataText": "No available choice"
+		},
+		"datepicker": {
+			"dateFormat": "AAAA/MM/JJ ou une expression ({{today}} ou  {{now}})",
+			"dateLabel": "Sélectionnez une date",
+			"endLabel": "Date de fin",
+			"startLabel": "Date de début",
+			"today": "Aujourd'hui",
+			"toggle": "Sélectionnez une date"
+		},
+		"datetimepicker": {
+			"accept": "Accepter",
+			"acceptLabel": "Accepter",
+			"cancel": "Annuler",
+			"cancelLabel": "Annuler",
+			"dateTab": "Date",
+			"dateTabLabel": "Date",
+			"now": "Maintenant",
+			"timeTab": "Heure",
+			"timeTabLabel": "Heure",
+			"today": "Aujourd'hui",
+			"toggle": "Sélectionnez une date et une heure"
+		},
+		"editor": {
+			"addColumnAfter": "Nouvelle colonne à droite",
+			"addColumnBefore": "Nouvelle colonne à gauche",
+			"addRowAfter": "Nouvelle ligne en bas",
+			"addRowBefore": "Nouvelle ligne en haut",
+			"alignCenter": "Centrer",
+			"alignJustify": "Justifier",
+			"alignLeft": "Aligner à gauche",
+			"alignRight": "Aligner à droite",
+			"backColor": "Couleur de fond",
+			"bold": "Gras",
+			"cleanFormatting": "Supprimer le format",
+			"createLink": "Nouveau lien",
+			"deleteColumn": "Supprimer la colonne",
+			"deleteRow": "Supprimer la ligne",
+			"deleteTable": "Supprimer la table",
+			"dialogApply": "Appliquer",
+			"dialogCancel": "Annuler",
+			"dialogInsert": "Insérer",
+			"dialogUpdate": "Modifier",
+			"fileText": "Texte",
+			"fileTitle": "Titre",
+			"fileWebAddress": "Adresse Web",
+			"fontFamily": "Sélectionnez une police de caractère",
+			"fontSize": "Sélectionnez la taille de police",
+			"foreColor": "Couleur",
+			"format": "Format",
+			"imageAltText": "Texte alternatif",
+			"imageHeight": "Hauteur (px)",
+			"imageWebAddress": "Adresse Web",
+			"imageWidth": "Largeur (px)",
+			"indent": "Augmenter le retrait",
+			"insertFile": "Nouveau fichier",
+			"insertImage": "Nouvelle image",
+			"insertOrderedList": "Nouvelle liste ordonnée",
+			"insertTable": "Nouvelle table",
+			"insertUnorderedList": "Nouvelle liste non-ordonnée",
+			"italic": "Italique",
+			"linkOpenInNewWindow": "Ouvrir dans une nouvelle fenêtre",
+			"linkText": "Texte",
+			"linkTitle": "Titre",
+			"linkWebAddress": "Adresse Web",
+			"outdent": "Diminuer le retrait",
+			"print": "Imprimer",
+			"redo": "Répéter",
+			"selectAll": "Tout sélectionner",
+			"strikethrough": "Barrer",
+			"subscript": "Indice",
+			"superscript": "Exposant",
+			"underline": "Souligner",
+			"undo": "Annuler",
+			"unlink": "Supprimer le lien",
+			"unselectAll": "Tout déselectionner",
+			"viewSource": "Voir la source"
+		},
+		"fileselect": {
+			"dropFilesHere": "Déposez les fichiers ici pour les sélectionner",
+			"select": "Choisir des fichiers..."
+		},
+		"grid": {
+			"columnMenu": "'Menu de la colonne {columnName}'",
+			"columns": "Colonnes",
+			"columnsApply": "Appliquer",
+			"columnsReset": "Réinitialiser",
+			"detailCollapse": "Réduire",
+			"detailExpand": "Étendre",
+			"filter": "Filtrer",
+			"filterAfterOperator": "Est après",
+			"filterAfterOrEqualOperator": "Est après ou égal à",
+			"filterAndLogic": "Et",
+			"filterBeforeOperator": "Est avant",
+			"filterBeforeOrEqualOperator": "Est avant ou égal à",
+			"filterBooleanAll": "(Tous)",
+			"filterClearButton": "Effacer",
+			"filterContainsOperator": "Contient",
+			"filterDateToday": "Aujourd'hui",
+			"filterDateToggle": "Afficher/masquer le calendrier",
+			"filterEndsWithOperator": "Termine par",
+			"filterEqOperator": "Est égal à",
+			"filterFilterButton": "Filtrer",
+			"filterGtOperator": "Est plus grand que",
+			"filterGteOperator": "Est plus grand que ou égal à",
+			"filterInputLabel": "'Filtrer {columnName}'",
+			"filterIsEmptyOperator": "Est vide",
+			"filterIsFalse": "est faux",
+			"filterIsInOperator": "Est dans",
+			"filterIsNotEmptyOperator": "Est non-vide",
+			"filterIsNotInOperator": "N'est pas dans",
+			"filterIsNotNullOperator": "Est non-nul",
+			"filterIsNullOperator": "Est nul",
+			"filterIsTrue": "est vrai",
+			"filterLtOperator": "Est plus petit que",
+			"filterLteOperator": "Est plus petit que ou égal à",
+			"filterMenuLogicDropDownLabel": "'Logique de filtre sur {columnName}'",
+			"filterMenuOperatorsDropDownLabel": "'Opérateurs de filtre sur {columnName}'",
+			"filterMenuTitle": "'Menu de filtre sur {columnName}'",
+			"filterNotContainsOperator": "Ne contient pas",
+			"filterNotEqOperator": "Est différent de",
+			"filterNumericDecrement": "Décrémenter la valeur",
+			"filterNumericIncrement": "Incrémenter la valeur",
+			"filterOrLogic": "Ou",
+			"filterStartsWithOperator": "Commence par",
+			"gridLabel": "Table de données",
+			"groupCollapse": "Réduire le groupe",
+			"groupExpand": "Étendre le groupe",
+			"groupPanelEmpty": "Faites glisser un en-tête de colonne et déposez-le ici pour grouper par cette colonne",
+			"loading": "Chargement",
+			"lock": "Verrouiller",
+			"noRecords": "Aucun enregistrement disponible",
+			"pagerFirstPage": "Aller à la première page",
+			"pagerItems": "éléments",
+			"pagerItemsPerPage": "éléments par page",
+			"pagerLabel": "'Navigation de page, page {currentPage} sur {totalPages}'",
+			"pagerLastPage": "Aller à la dernière page",
+			"pagerNextPage": "Aller à la page suivante",
+			"pagerOf": "sur",
+			"pagerPage": "Page",
+			"pagerPageNumberInputTitle": "Numéro de page",
+			"pagerPreviousPage": "Aller à la page précédente",
+			"selectAllCheckboxLabel": "Tout sélectionner",
+			"selectionCheckboxLabel": "Sélectionner la ligne",
+			"setColumnPosition": "Définir la position de la colonne",
+			"sortAscending": "Trier par ordre croissant",
+			"sortDescending": "Trier par ordre décroissant",
+			"sortable": "Triable",
+			"sortedAscending": "Trié par ordre croissant",
+			"sortedDefault": "Non trié",
+			"sortedDescending": "Trié par ordre décroissant",
+			"stick": "Épingler",
+			"unlock": "Déverrouiller",
+			"unstick": "Désépingler"
+		},
+		"multiselect": {
+			"clearTitle": "Supprimer la valeur",
+			"noDataText": "No available choice"
+		},
+		"pager": {
+			"firstPage": "Aller à la première page",
+			"items": "éléments",
+			"itemsPerPage": "éléments par page",
+			"label": "'Navigation de page, page {currentPage} sur {totalPages}'",
+			"lastPage": "Aller à la dernière page",
+			"nextPage": "Aller à la page suivante",
+			"of": "sur",
+			"page": "Page",
+			"pageNumberInputTitle": "Numéro de page",
+			"previousPage": "Aller à la page précédente"
+		},
+		"tilelayout": {
+			"component": {
+				"items": "articles",
+				"itemsPerPage": "Articles par page",
+				"of": "de",
+				"page": "Page"
+			}
+		},
+		"timepicker": {
+			"accept": "Accepter",
+			"acceptLabel": "Accepter",
+			"cancel": "Annuler",
+			"cancelLabel": "Annuler",
+			"now": "Maintenant",
+			"toggle": "Sélectionner une heure"
+		},
+		"upload": {
+			"dropFilesHere": "Déposez les fichiers ici pour les importer",
+			"invalidMaxFileSize": "Taille du fichier trop grande.",
+			"select": "Sélectionner les fichiers..."
+		}
+	},
+	"models": {
+		"apiConfiguration": {
+			"authType": "Type d'authentification",
+			"new": "Nouvelle configuration d'API",
+			"selectAuthType": "Sélectionnez le type d'authentification"
+		},
+		"application": {
+			"description": "Description",
+			"errors": {
+				"style": {
+					"notFound": "Le style de l'application n'a pas pu être chargé"
+				}
+			},
+			"id": "ID de l'application",
+			"menu": "Menu latéral",
+			"new": "Nouvelle application",
+			"notifications": {
+				"notPublished": "L'application n'a pas pu être publiée.",
+				"published": "L'application {{value}} a été publiée.",
+				"updated": "Application modifiée."
+			},
+			"setAsFavorite": "Ajouter aux favoris",
+			"subscription": {
+				"create": "Créer un abonnement"
+			}
+		},
+		"channel": {
+			"create": "Créer un canal de diffusion",
+			"edit": "Modifier le canal",
+			"new": "Nouveau canal de diffusion"
+		},
+		"customNotification": {
+			"lastExecution": "Dernière exécution",
+			"schedule": "Fréquence",
+			"type": "Type"
+		},
+		"dashboard": {
+			"activateFiltering": "Activer le filtre",
+			"buttonActions": {
+				"add": "Ajouter une action de bouton",
+				"category": "Catégorie de bouton",
+				"confirmDelete": "Voulez-vous vraiment supprimer cette action de bouton ?",
+				"edit": "Modifier l'action du bouton",
+				"href": {
+					"title": "Bouton href",
+					"tooltip": "L'attribut href spécifie l'URL de destination lorsque le bouton est cliqué. Peut être une URL relative ou absolue."
+				},
+				"one": "Action du bouton",
+				"openInNewTab": "Ouvrir dans un nouvel onglet",
+				"text": "Texte du bouton",
+				"variant": "Variante de bouton"
+			},
+			"closable": "Peut être fermé",
+			"context": {
+				"datasource": {
+					"alert": "Sélectionnez une source de données, afin de définir une page par enregistrement de la source de données. Vous pouvez également définir un modèle qui sera chargé par défaut si aucune page spécifique n'est créée pour un enregistrement.",
+					"info": "Indiquez le champ à utiliser lors de la sélection des enregistrements.",
+					"set": "Définir la source de données contextuelle",
+					"title": "Source de données contextuelle",
+					"update": "Mettre à jour la source de données contextuelle"
+				},
+				"displayField": "Champ d'affichage",
+				"edition": {
+					"element": "Vous éditez la page qui sera affichée pour l'élément sélectionné.",
+					"template": "Vous éditez le modèle de base de la page. Il sera utilisé par défaut si aucune vue n'a été créée pour l'élément à charger."
+				},
+				"notifications": {
+					"creatingTemplate": "Création d'une nouvelle vue",
+					"loadDefault": "Affichage de la vue générique",
+					"templateCreated": "Nouvelle vue créée"
+				},
+				"origin": "Origine du contexte",
+				"refData": {
+					"element": "Élément"
+				},
+				"selectDisplayField": "Sélectionnez le champ d'affichage",
+				"selectOrigin": "Sélectionnez la source de données",
+				"title": "Contexte",
+				"tooltip": {
+					"useContextEditor": "Utiliser l'éditeur de contexte",
+					"useDefaultEditor": "Utiliser l'éditeur par défaut"
+				}
+			},
+			"contextFilter": "Filtre contextuel",
+			"dashboardFilter": "Filtre du tableau de bord",
+			"deactivateFiltering": "Désactiver le filtre",
+			"filterVariant": {
+				"title": "Variante de filtre",
+				"variantsOptions": {
+					"selectOrigin": "Sélectionner une variante de filtre",
+					"variant_default": "Défaut",
+					"variant_modern": "Moderne"
+				}
+			},
+			"historicalDate": "Récupérer les données historiques",
+			"share": "Partager le tableau de bord",
+			"tooltip": {
+				"filter": {
+					"closable": "Lorsque la variante est moderne ou que l'application est utilisée comme élément web, un bouton s'affichera pour permettre à l'utilisateur de cacher le filtre",
+					"fields": "Vous pouvez utiliser les champs du filtre du tableau de bord, ou utiliser des valeurs statiques.",
+					"position": "Ne s'applique que lorsque la variant par défaut est active"
+				},
+				"historicalDate": "Vous pouvez récupérer les données à une date spécifique en utilisant un champ du filtre du tableau de board.\nVeuillez alors utiliser cette syntaxe : {{filter.<nom>}}."
+			}
+		},
+		"form": {
+			"core": "Source",
+			"create": "Créer un formulaire",
+			"edit": "Modifier le formulaire",
+			"field": {
+				"itemsLabel": "Éléments d'étiquette",
+				"label": "Étiquette",
+				"name": "Nom du champ",
+				"usedIn": "Utilisé par"
+			},
+			"new": "Nouveau formulaire",
+			"notifications": {
+				"savingFailed": "Échec de l'enregistrement, certains champs nécessitent votre attention."
+			},
+			"select": "Sélectionner un formulaire",
+			"template": "Modèle"
+		},
+		"group": {
+			"create": "Créer un groupe",
+			"description": "Description",
+			"fetch": "Récupérer les groupes du service",
+			"title": "Titre"
+		},
+		"mapping": {
+			"add": "Ajouter un rang à la table de correspondances",
+			"edit": "Modifier un rang de la table de correspondances"
+		},
+		"page": {
+			"add": "Ajouter une page",
+			"tooltip": {
+				"drag": "Glissez-déposez pour réorganiser",
+				"duplicate": "Sélectionner l'application où copier la page"
+			}
+		},
+		"positionAttribute": {
+			"edit": "Modifier l'attribut de position",
+			"new": "Nouvel attribut de position"
+		},
+		"pullJob": {
+			"edit": "Modifier une tâche planifiée",
+			"new": "Nouvelle tâche planifiée",
+			"nextIteration": "Prochaine exécution",
+			"path": "Chemin",
+			"schedule": "Horaire planifié",
+			"url": "Url"
+		},
+		"record": {
+			"convert": "Convertir",
+			"edit": "Modifier l'enregistrement",
+			"new": "Nouvel enregistrement",
+			"notifications": {
+				"conversionIncomplete": "Il n'y a pas de correspondance entre le(s) enregistrement(s) sélectionné(s) et certains champs de ce formulaire.",
+				"rowsAdded": "{{length}} ligne(s) ont été ajoutées à {{field}} dans l'enregistrement {{value}}.",
+				"rowsNotAdded": "Erreur lors de l'ajout de ligne(s).",
+				"uploadSuccessful": "Enregistrements importés avec succès"
+			},
+			"restore": "Restaurer",
+			"select": "Sélectionnez un enregistrement"
+		},
+		"referenceData": {
+			"add": "Ajouter une référence de données",
+			"select": "Sélectionnez une référence de données"
+		},
+		"resource": {
+			"create": "Créer une ressource",
+			"select": "Sélectionnez une ressource"
+		},
+		"role": {
+			"create": "Créer un rôle",
+			"description": "Description",
+			"title": "Titre"
+		},
+		"step": {
+			"new": "Nouvelle étape"
+		},
+		"subscription": {
+			"edit": "Modifier l'abonnement",
+			"new": "Nouvel abonnement"
+		},
+		"user": {
+			"firstName": "Prénom",
+			"lastName": "Nom",
+			"notifications": {
+				"rolesUpdated": "Les rôles de {{username}} ont été modifiés.",
+				"userImportFail": "L'importation d'utilisateurs a échoué."
+			},
+			"username": "Nom d'utilisateur"
+		},
+		"widget": {
+			"add": "Ajouter un widget",
+			"chart": {
+				"defaultTitle": "Widget Graphique"
+			},
+			"delete": {
+				"confirmationMessage": "Souhaitez-vous supprimer le widget ?",
+				"title": "Supprimer le widget"
+			},
+			"display": {
+				"border": "Afficher la bordure du widget",
+				"expand": "Afficher le bouton pour développer le widget",
+				"header": "Afficher l'en-tête du widget",
+				"padding": "Utiliser la marge intérieure du widget",
+				"searchable": "Autoriser la recherche",
+				"sortable": "Autoriser le tri",
+				"title": "Affichage des widgets",
+				"tooltip": "afficher l'info-bulle"
+			},
+			"map": {
+				"defaultTitle": "Widget Carte",
+				"latitude": "Latitude",
+				"longitude": "Longitude",
+				"zoom": "Zoom"
+			},
+			"sorting": {
+				"add": "Ajouter un champ",
+				"delete": "Supprimer le champ de tri",
+				"empty": "Aucun champ de tri défini",
+				"field": "Champ",
+				"label": "Étiquette",
+				"management": "Gestion des champs de tri",
+				"order": "Ordre",
+				"select": "Sélectionnez un champ de tri...",
+				"title": "Tri"
+			},
+			"tooltip": {
+				"expandButton": {
+					"expand": "Étendre le widget",
+					"help": "Apparaît uniquement dans le front-office ou en mode prévisualisation.",
+					"restore": "Restaurer la taille"
+				},
+				"selector": {
+					"collapse": "Fermer la sélection de widget",
+					"expand": "Afficher la sélection de widget"
+				}
+			}
+		},
+		"workflow": {
+			"notifications": {
+				"cannotGoToNextStep": "Impossible de passer à l'étape suivante",
+				"cannotGoToPreviousStep": "Impossible de passer à l'étape précédente",
+				"goToStep": "De retour à l'étape {{step}}."
+			}
+		}
+	},
+	"pages": {
+		"administration": {
+			"title": "Administration"
+		},
+		"aggregation": {
+			"preview": {
+				"label": "Aperçu des données d'agrégation",
+				"missingAggregation": "Impossible de charger l'agrégation sélectionnée. Agrégation introuvable"
+			}
+		},
+		"apiConfiguration": {
+			"authentication": "Paramètres d'authentification",
+			"baseUrl": "Point d'arrivée principal",
+			"clientId": "ID Client",
+			"graphQL": {
+				"endpoint": "Point d'accès GraphQL",
+				"title": "Paramètres de GraphQL"
+			},
+			"host": "Paramètres de l'hôte",
+			"notifications": {
+				"authTokenFetched": "Jeton d'authentification récupéré, faîtes un autre ping pour obtenir la vraie réponse.",
+				"pingFailed": "La requête ping a échoué.",
+				"pingReceived": "La requête ping a reçu une réponse positive."
+			},
+			"ping": "Essayer avec ces paramètres",
+			"pingUrl": "Extension ping",
+			"placeholder": {
+				"baseUrl": "URL de base pour l'API",
+				"clientId": "Entrez l'ID Client",
+				"graphQLEndpoint": "Extension GraphQL",
+				"pingUrl": "Entrez l'URL de l'extension ping",
+				"scope": "Entrer le scope",
+				"secret": "Entrer le client secret",
+				"token": "Entrez le jeton d'accès pour l'authentification",
+				"tokenUrl": "Entrez l'URL du jeton d'accès"
+			},
+			"scope": "Scope",
+			"secret": "Client Secret",
+			"token": "Jeton d'accès",
+			"tokenUrl": "URL du jeton d'accès"
+		},
+		"apiConfigurations": {
+			"create": "Créer une configuration d'API"
+		},
+		"appBuilder": {
+			"title": "Création de site"
+		},
+		"application": {
+			"addPage": {
+				"form": {
+					"title": "Formulaires disponibles"
+				},
+				"selectType": "Sélectionnez le type de page que vous voulez créer",
+				"startFromWidget": "Commencer avec un widget"
+			},
+			"empty": {
+				"add": "Ajouter une page",
+				"create": "Cliquez sur créer pour terminer le processus",
+				"customize": "Personnalisez chacune des pages créées"
+			},
+			"positionAttributes": {
+				"create": "Créer une catégorie de position",
+				"title": "Attributs"
+			},
+			"settings": {
+				"actions": "Actions"
+			}
+		},
+		"applications": {
+			"all": "Toutes les applications",
+			"goTo": "Aller vers la liste d'applications",
+			"recent": "Applications récentes",
+			"title": "Mes applications"
+		},
+		"dashboard": {
+			"update": {
+				"exit": "Quitter sans sauvegarder les changements",
+				"exitMessage": "Il y a des changements non sauvegardés dans la page, voulez-vous vraiment quitter cette page ?"
+			}
+		},
+		"formBuilder": {
+			"errors": {
+				"choices": {
+					"valueDuplicated": "Veuillez configurer des valeurs uniques pour les choix de la question : {{question}}"
+				},
+				"dataFieldDuplicated": "Doublon de nom de valeur : {{name}}. Indiquez un nom de valeur distinct pour chaque question.",
+				"missingName": "Nom manquant pour un élément de la page : {{page}}. Veuillez configurer un nom valide (en format snake_case) pour sauvegarder le formulaire.",
+				"multipletext": {
+					"missingName": "Veuillez configurer un nom ou titre pour chaque champ de text de la question : {{question}}"
+				},
+				"selectApplication": "Application manquante pour un élément de la page : {{page}}. Veuillez sélectionner au moins une application dans les propriétés de {{question}} pour sauvegarder le formulaire.",
+				"snakecase": "Le nom de valeur {{name}} de la page {{page}} est invalide. Veuillez configurer un nom valide (en format snake_case) pour sauvegarder le formulaire."
+			},
+			"move": {
+				"down": "Descendre la question",
+				"up": "Monter la question"
+			},
+			"questionsCategories": {
+				"core": "Bibliothèque de questions"
+			},
+			"title": "Paramètres avancés"
+		},
+		"forms": {
+			"title": "Formulaires disponibles"
+		},
+		"profile": {
+			"notifications": {
+				"notUpdated": "Erreur lors de l'enregistrement des préférences.",
+				"updated": "Préférences sauvegardées."
+			},
+			"password": {
+				"change": "Changer le mot de passe"
+			},
+			"title": "Votre profil"
+		},
+		"pullJobs": {
+			"create": "Créer une tâche planifiée"
+		},
+		"referenceData": {
+			"csv": "Fichier CSV d'entrée",
+			"fields": {
+				"fetch": "Récupérer les champs",
+				"help": "Les champs sont calculés en fonction des attributs du premier élément dans la réponse de l'API",
+				"missingConfig": "Impossible de récupérer les champs. Configuration manquante : {{config}}",
+				"noFields": "Aucun champ trouvé",
+				"title": "Champ"
+			},
+			"graphQLFilter": "Paramètres de la requête GraphQL",
+			"pagination": {
+				"cursorPath": "Chemin du curseur",
+				"cursorVariable": "Variable de requête de curseur",
+				"offsetVariable": "Variable de requête de décalage",
+				"pageSizeVariable": "Variable de requête de taille de page",
+				"pageVariable": "Variable de requête de numéro de page",
+				"strategy": "Stratégie de pagination",
+				"totalCountPath": "Chemin du nombre total d'articles",
+				"usePagination": {
+					"hint": "Dépend de la prise en charge de l'API, permet de récupérer des données par page",
+					"text": "Utiliser la pagination"
+				}
+			},
+			"path": {
+				"placeholder": "Entrez un JSONPath valide",
+				"title": "Chemin de données"
+			},
+			"payload": {
+				"label": "Réponse de l'API",
+				"show": "Afficher la réponse de l'API"
+			},
+			"placeholder": {
+				"csv": "Insérer le CSV ici",
+				"graphQLFilter": "Entrez un filtre graphQL qui sera utilisé une fois les choix cachés"
+			},
+			"queryName": "Nom de la requête",
+			"tooltip": {
+				"graphQLFilter": "Vous pouvez utiliser {{lastUpdate}} pour obtenir dynamiquement la dernière date de récupération au format SQL.",
+				"path": "Utilise la syntaxe JSONPath pour extraire les éléments de la réponse JSON. Exemples: $.data[*].name, $.data..countries, $.data.countries.*"
+			},
+			"type": "Type",
+			"validateCsv": "Valider le CSV",
+			"valueField": "Champ de valeur"
+		},
+		"workflow": {
+			"addStep": {
+				"selectType": "Sélectionner quel type d'étape vous voulez créer."
+			},
+			"deleteStep": {
+				"confirmationMessage": "Souhaitez-vous supprimer définitivement l'étape {{step}} ?"
+			},
+			"empty": {
+				"add": "Ajoutez des étapes",
+				"customize": "Personnalisez chacune des étapes créées."
+			}
+		}
+	}
 }

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2521,6 +2521,9 @@
 				"notUpdated": "******",
 				"updated": "******"
 			},
+			"password": {
+				"change": "******"
+			},
 			"title": "******"
 		},
 		"pullJobs": {

--- a/libs/shared/src/lib/components/query-builder/query-builder-forms.ts
+++ b/libs/shared/src/lib/components/query-builder/query-builder-forms.ts
@@ -158,7 +158,7 @@ export const createQueryForm = (value: any, validators = true) =>
 export const createDisplayForm = (value: any) =>
   formBuilder.group({
     showFilter: [value?.showFilter],
-    actionsColWidth: [value?.actionsColWidth || 86],
+    actionsColWidth: [value?.actionsColWidth || 54],
     sort: [value?.sort || []],
     fields: [value?.fields || null],
     filter: [value?.filter || null],

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.html
@@ -29,7 +29,7 @@
   [widget]="widget"
   [canUpdate]="canUpdate"
   [canAdd]="canCreateRecords"
-  [actionsWidth]="defaultLayout.actionsColWidth ?? 86"
+  [actionsWidth]="defaultLayout.actionsColWidth ?? 54"
   [searchable]="searchable"
 >
 </shared-grid>

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -103,7 +103,7 @@ export class GridComponent
   /** Input decorator for fields. */
   @Input() fields: any[] = [];
   /** Input decorator the the action column width */
-  @Input() actionsWidth = 86;
+  @Input() actionsWidth = 54;
   /** Input decorator for data. */
   @Input() data: GridDataResult = { data: [], total: 0 };
   /** Input decorator for loadingRecords. */


### PR DESCRIPTION
# Description

In grid widgets, the last column is dedicated to actions if there are any. Each cell can contain the dropdown list of actions and another icon if the line is being updated. The default column width had been set too fit these two elements, but the second icon is not always visible. The logic already handles size changes when showing or hiding icons, but the default value was too large. I configured it to be the icon width plus the padding. Since the column doesn't have a name by default, if no records are displayed, then an empty box is there in the table head. It could be remove if necessary.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/browse/HIT-260)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a new layout for a resource and a new dashboard with a grid widget. I verified the width of the last column.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/668847f6-7e6e-47a3-9b64-1c498b40f03b)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
