### PR TITLE
HIT-338-RefData-semicolon-transformed-into-comma-of-CSV-input

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/reference-data/graphql/mutations.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/graphql/mutations.ts
@@ -14,6 +14,7 @@ export const EDIT_REFERENCE_DATA = gql`
     $path: String
     $data: JSON
     $graphQLFilter: String
+    $separator: String
     $permissions: JSON
     $pageInfo: PageInfoInput
   ) {
@@ -28,6 +29,7 @@ export const EDIT_REFERENCE_DATA = gql`
       path: $path
       data: $data
       graphQLFilter: $graphQLFilter
+      separator: $separator
       permissions: $permissions
       pageInfo: $pageInfo
     ) {
@@ -43,6 +45,7 @@ export const EDIT_REFERENCE_DATA = gql`
       valueField
       path
       data
+      separator
       permissions {
         canSee {
           id

--- a/apps/back-office/src/app/dashboard/pages/reference-data/graphql/queries.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/graphql/queries.ts
@@ -18,6 +18,7 @@ export const GET_REFERENCE_DATA = gql`
       path
       data
       graphQLFilter
+      separator
       permissions {
         canSee {
           id

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -385,11 +385,11 @@
       <div class="flex gap-2 items-center">
         <div uiFormFieldDirective class="flex-1">
           <label>{{ 'common.separator' | translate }}</label>
-          <ui-select-menu [formControl]="separator">
-            <ui-select-option value=",">{{
+          <ui-select-menu formControlName="separator">
+            <ui-select-option [value]="','">{{
               'common.comma' | translate
             }}</ui-select-option>
-            <ui-select-option value=";">{{
+            <ui-select-option [value]="';'">{{
               'common.semicolon' | translate
             }}</ui-select-option>
           </ui-select-menu>

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.form.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.form.ts
@@ -32,6 +32,7 @@ export const createRefDataForm = (refData?: ReferenceData) => {
     path: new FormControl(get(refData, 'path')),
     data: new FormControl(get(refData, 'data')),
     usePagination: new FormControl(!!get(refData, 'pageInfo.strategy')),
+    separator: new FormControl(get(refData, 'separator', ',') || ','),
     pageInfo: new FormGroup({
       strategy: new FormControl(get(refData, 'pageInfo.strategy')),
       totalCountField: new FormControl(

--- a/libs/shared/src/lib/models/reference-data.model.ts
+++ b/libs/shared/src/lib/models/reference-data.model.ts
@@ -31,6 +31,7 @@ export interface ReferenceData {
   path?: string;
   data?: any;
   graphQLFilter?: string;
+  separator?: string;
   permissions?: any;
   canSee?: boolean;
   canUpdate?: boolean;


### PR DESCRIPTION
# Description
Added to the ReferenceData model the separator property, so it can be saved and checked when opening already-existing reference data if the csv must be built with a custom separator instead of the default comma

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-338
- Please insert link to back-end branch if any: https://github.com/ReliefApplications/oort-backend/pull/51

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
As described in the attached video

## Screenshots
[video.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/f9eb0550-344a-416e-9eb9-a31d5dd1efa1)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
