### PR TITLE
HIT-334-Tabs-in-Resources-not-always-loading-when-clicking

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
@@ -5,17 +5,8 @@
   [dataSource]="aggregations"
   [canUpdate]="resource.canUpdate ?? false"
   [displayedColumns]="displayedColumnsAggregations"
+  [pageInfo]="pageInfo"
+  (pageChange)="onPage($event)"
   (itemAction)="handleAction($event)"
 >
-  <ng-container ngProjectAs="pagination">
-    <ui-paginator
-      [disabled]="loading"
-      [pageIndex]="pageInfo.pageIndex"
-      [pageSize]="pageInfo.pageSize"
-      [pageSizeOptions]="[10, 25, 50]"
-      [totalItems]="pageInfo.length"
-      (pageChange)="onPage($event)"
-    >
-    </ui-paginator>
-  </ng-container>
 </app-data-presentation-list>

--- a/apps/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.module.ts
@@ -4,7 +4,6 @@ import { AggregationsTabRoutingModule } from './aggregations-tab-routing.module'
 import { OverlayModule } from '@angular/cdk/overlay';
 import { AggregationBuilderModule } from '@oort-front/shared';
 import { AggregationsTabComponent } from './aggregations-tab.component';
-import { PaginatorModule } from '@oort-front/ui';
 import { DataPresentationListComponent } from '../components/data-presentation-list/data-presentation-list.component';
 
 /**
@@ -17,7 +16,6 @@ import { DataPresentationListComponent } from '../components/data-presentation-l
     AggregationsTabRoutingModule,
     AggregationBuilderModule,
     OverlayModule,
-    PaginatorModule,
     DataPresentationListComponent,
   ],
 })

--- a/apps/back-office/src/app/dashboard/pages/resource/components/data-presentation-list/data-presentation-list.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/components/data-presentation-list/data-presentation-list.component.html
@@ -73,7 +73,15 @@
       </div>
     </div>
     <!-- Pagination -->
-    <ng-content select="pagination"></ng-content>
+    <ui-paginator
+      [disabled]="loading"
+      [pageIndex]="pageInfo.pageIndex"
+      [pageSize]="pageInfo.pageSize"
+      [pageSizeOptions]="[10, 25, 50]"
+      [totalItems]="pageInfo.length"
+      (pageChange)="onPage($event)"
+    >
+    </ui-paginator>
   </ng-container>
   <ng-template #emptyTmpl>
     <!-- Empty indicator -->

--- a/apps/back-office/src/app/dashboard/pages/resource/components/data-presentation-list/data-presentation-list.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/components/data-presentation-list/data-presentation-list.component.ts
@@ -13,8 +13,10 @@ import {
   DividerModule,
   IconModule,
   MenuModule,
+  PaginatorModule,
   TableModule,
   TooltipModule,
+  UIPageChangeEvent,
 } from '@oort-front/ui';
 
 /**
@@ -35,6 +37,7 @@ import {
     TranslateModule,
     TooltipModule,
     DateModule,
+    PaginatorModule,
   ],
   templateUrl: './data-presentation-list.component.html',
   styleUrls: ['./data-presentation-list.component.scss'],
@@ -66,6 +69,16 @@ export class DataPresentationListComponent {
   @Input() displayedColumns: string[] = [];
 
   /**
+   * Page information of the current displayed list
+   */
+  @Input() pageInfo = {
+    pageIndex: 0,
+    pageSize: 10,
+    length: 0,
+    endCursor: '',
+  };
+
+  /**
    * Event emitter for the item action
    */
   @Output() itemAction: EventEmitter<{
@@ -75,6 +88,12 @@ export class DataPresentationListComponent {
     type: 'add' | 'edit' | 'delete';
     item: Aggregation | Layout | null | undefined;
   }>();
+
+  /**
+   * Page change event emit from pagination
+   */
+  @Output()
+  pageChange = new EventEmitter<UIPageChangeEvent>();
 
   /** @returns True if the dataSource tab is empty */
   get empty(): boolean {
@@ -92,5 +111,14 @@ export class DataPresentationListComponent {
     item?: Aggregation | Layout | null | undefined
   ) {
     this.itemAction.emit({ type, item });
+  }
+
+  /**
+   * Emit pagination change event to parent component
+   *
+   * @param event Current UI page change event
+   */
+  onPage(event: UIPageChangeEvent) {
+    this.pageChange.emit(event);
   }
 }

--- a/apps/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
@@ -5,17 +5,8 @@
   [dataSource]="layouts"
   [canUpdate]="resource.canUpdate ?? false"
   [displayedColumns]="displayedColumnsLayouts"
+  [pageInfo]="pageInfo"
+  (pageChange)="onPage($event)"
   (itemAction)="handleAction($event)"
 >
-  <ng-container ngProjectAs="pagination">
-    <ui-paginator
-      [disabled]="loading"
-      [pageIndex]="pageInfo.pageIndex"
-      [pageSize]="pageInfo.pageSize"
-      [pageSizeOptions]="[10, 25, 50]"
-      [totalItems]="pageInfo.length"
-      (pageChange)="onPage($event)"
-    >
-    </ui-paginator>
-  </ng-container>
 </app-data-presentation-list>

--- a/apps/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { LayoutsTabRoutingModule } from './layouts-tab-routing.module';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { LayoutsTabComponent } from './layouts-tab.component';
-import { PaginatorModule } from '@oort-front/ui';
 import { DataPresentationListComponent } from '../components/data-presentation-list/data-presentation-list.component';
 
 /**
@@ -15,7 +14,6 @@ import { DataPresentationListComponent } from '../components/data-presentation-l
     CommonModule,
     LayoutsTabRoutingModule,
     OverlayModule,
-    PaginatorModule,
     DataPresentationListComponent,
   ],
 })

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -81,7 +81,7 @@ export class PaginatorComponent implements OnChanges, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.resizeObserver.disconnect();
+    this.resizeObserver?.disconnect();
   }
 
   /**


### PR DESCRIPTION
# Description
Removed ui-paginator projection from layout and aggregation tabs of the Resource page, as the parentElement property used in the paginator component was not accessible on projection load, and onDestroy the resize observator breaks. Added paginator in the data-presentation-list component.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-334


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
As described in the attached video

## Screenshots

[video.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/e26f439d-f7bf-46c5-b3f3-1037d0068344)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
