### PR TITLE
fix/HIT-348-Record-update-displaying-previous-value

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -121,7 +121,10 @@ export class FormComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.record) {
+    if (
+      changes.record &&
+      changes.record.currentValue.id !== changes.record.previousValue.id
+    ) {
       this.initSurvey();
     }
   }

--- a/libs/ui/src/lib/fixed-wrapper/fixed-wrapper.component.html
+++ b/libs/ui/src/lib/fixed-wrapper/fixed-wrapper.component.html
@@ -1,6 +1,6 @@
 <ng-template #fixedWrapperActions>
   <div
-    class="z-[1] sticky bottom-0 right-0 py-2 px-4 bg-white w-full shadow-lg transition-shadow duration-300 shadow-slate-700 border-t border-gray-300"
+    class="z-[99] sticky bottom-0 right-0 py-2 px-4 bg-white w-full shadow-lg transition-shadow duration-300 shadow-slate-700 border-t border-gray-300"
   >
     <div class="flex w-full justify-end">
       <!-- Inject actions -->


### PR DESCRIPTION
# Description
fix: in the FormComponent, the onChanges hook was incorrectly triggering initSurvey and setting the survey data with the record data (old data)
fix: In the Update record, the resouces questions grid was above the fixed-wrapped with theaction buttons

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-348

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
As described in the attached video

## Screenshots
[hit-348.webm](https://github.com/user-attachments/assets/df848c7d-d197-4a35-b919-90b3dfa6b2ca)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
