### PR TITLE
[HIT-378] Display issue with forms in workflows

### DIFF
--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -25,9 +25,8 @@
     ></div>
     <div class="h-full w-full relative">
       <div
-        [ngClass]="{ 'pb-[64px]': fixedWrapperActionExist }"
+        [ngClass]="resolveContentWrapperClasses()"
         id="appPageContainer"
-        class="py-[32px] overflow-y-auto overflow-x-hidden h-full px-[24px] flex flex-col absolute inset-0"
         #contentWrapper
       >
         <ng-content select="content"></ng-content>

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.ts
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.ts
@@ -58,6 +58,8 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
   fixedWrapperActionExist = false;
   /** Timeout to transitions */
   private transitionsTimeoutListener!: NodeJS.Timeout;
+  /** Tailwind classes for content wrapper */
+  public wrapperClasses: string[] = [];
 
   /** @returns height of element */
   get height() {
@@ -206,6 +208,36 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
         'shadow-[0_4px_12px_0_rgba(0,0,0,0.07),_0_2px_4px_rgba(0,0,0,0.05)]'
       );
     }
+    return classes;
+  }
+
+  /**
+   * Resolve content wrapper classes
+   */
+  resolveContentWrapperClasses(): string[] {
+    const classes = [
+      'py-[32px]',
+      'overflow-y-auto',
+      'overflow-x-hidden',
+      'h-full',
+      'px-[24px]',
+      'flex',
+      'flex-col',
+      'absolute',
+      'inset-0',
+    ];
+
+    if (this.fixedWrapperActionExist) {
+      classes.push('pb-[64px]');
+    }
+
+    // Update the class list for the wrapper element
+    const contentWrapperElement =
+      this.contentWrapper?.nativeElement.querySelector('app-workflow');
+    if (contentWrapperElement) {
+      contentWrapperElement.classList.add(...classes);
+    }
+
     return classes;
   }
 


### PR DESCRIPTION
# Description

the issue has to do with the structure of the rendered dom when there is a workflow. we already have this in the code that works for non-workflow form dashboards in sidenav-container.html:
`[ngClass]="{ 'pb-[64px]': fixedWrapperActionExist }"`
which adds this padding to the content wrapper of id appPageContainer, but this content wrapper is only a direct parent of the form app when its not a workflow.
when it is a workflow, appPageContainer renders an app-workflow which then renders the app-form, so we need to add those classes to app-workflow as well, including pb-[64px] when there is a fixed action bar.
i moved the wrapper classes to a function and added them to app-workflow when suitable. the only thing is i have no idea why this bug doesnt occur on back-office, but this correction doesnt seem to affect it

## Useful links

- https://oortcloud.atlassian.net/browse/HIT-378

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://github.com/user-attachments/assets/3ab9feaf-0c5b-48d9-aa05-0f66fc5c6cc7)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings