### PR TITLE
[HIT-404] Default value not being filled when asking for new record

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -196,26 +196,21 @@ export class FormComponent
    */
   public reset(): void {
     this.survey.clear();
-    /** Adding variables */
-    this.formHelpersService.addUserVariables(this.survey);
-    this.formHelpersService.addApplicationVariables(this.survey);
-    this.formHelpersService.setWorkflowContextVariable(this.survey);
+    this.survey.data = {};
     /** Clear temporary files */
     this.temporaryFilesStorage.clear();
-    /** Reset custom variables */
-    this.formHelpersService.addUserVariables(this.survey);
     /** Force reload of the survey so default value are being applied */
     this.survey.fromJSON(this.survey.toJSON());
     /** Adding variables */
     this.formHelpersService.addUserVariables(this.survey);
     this.formHelpersService.addApplicationVariables(this.survey);
     this.formHelpersService.setWorkflowContextVariable(this.survey);
+    /** Reset custom variables */
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });
     if (this.resetTimeoutListener) {
       clearTimeout(this.resetTimeoutListener);
     }
-    this.survey.data = {};
     this.resetTimeoutListener = setTimeout(
       () => (this.surveyActive = true),
       100

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -196,7 +196,6 @@ export class FormComponent
    */
   public reset(): void {
     this.survey.clear();
-    this.survey.data = {};
     /** Clear temporary files */
     this.temporaryFilesStorage.clear();
     /** Force reload of the survey so default value are being applied */


### PR DESCRIPTION
# Description

Fixed: Default value not being filled when asking for a new record.

## Useful links

[ticket](https://oortcloud.atlassian.net/browse/HIT-404)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Creating a form with one question with default value. Going to add records view, adding a new record, clicking in add new record and checking if the form reset with the default value in the question.

## Screenshots

![Peek 08-10-2024 11-43](https://github.com/user-attachments/assets/e443054f-f299-4b51-94d1-ba937d71676f)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145

