### PR TITLE
MAB-247: auto modify prompt now configurable

### DIFF
--- a/apps/front-office/src/app/application/pages/form/form.component.html
+++ b/apps/front-office/src/app/application/pages/form/form.component.html
@@ -9,7 +9,7 @@
   ></shared-upload-records>
   <shared-form [form]="form" (save)="onComplete($event)"></shared-form>
   <ng-container *ngIf="completed && !form.uniqueRecord && !hideNewRecord">
-    <ui-button class="ml-auto w-fit" category="secondary" (click)="clearForm()">
+    <ui-button class="mx-auto w-fit" category="secondary" (click)="clearForm()">
       {{ 'models.record.new' | translate }}
     </ui-button>
   </ng-container>

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1781,6 +1781,11 @@
                 "previous": "Go to previous step"
               }
             },
+            "confirmation": {
+              "defaultText": "Are you sure you want to delete this record?",
+              "text": "Confirmation text (optional)",
+              "title": "Confirm action"
+            },
             "create": "Add a button",
             "defaultName": "Action button",
             "enable": "Enable",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1794,6 +1794,11 @@
                 "previous": "Aller à l'étape précédente"
               }
             },
+            "confirmation": {
+              "defaultText": "Êtes-vous sûr de vouloir supprimer cet enregistrement ?",
+              "text": "Texte de confirmation (facultatif)",
+              "title": "Confirmer l'action"
+            },
             "create": "Ajouter un bouton",
             "defaultName": "Bouton d'action",
             "enable": "Activer",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1781,6 +1781,11 @@
                 "previous": "******"
               }
             },
+            "confirmation": {
+              "defaultText": "******",
+              "text": "******",
+              "title": "******"
+            },
             "create": "******",
             "defaultName": "******",
             "enable": "******",

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -225,6 +225,21 @@
                 | translate
             }}</ng-container>
           </ui-toggle>
+          <div
+            uiFormFieldDirective
+            *ngIf="formGroup.value.requireConfirmation"
+            class="flex-auto"
+          >
+            <ui-textarea
+              formControlName="modifyConfirmationText"
+              [minRows]="3"
+              [placeholder]="
+                'components.widget.settings.grid.buttons.confirmation.text'
+                  | translate
+              "
+            >
+            </ui-textarea>
+          </div>
           <form
             [formGroup]="$any(modification)"
             *ngFor="let modification of modificationsArray.controls; index as i"

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.module.ts
@@ -17,6 +17,7 @@ import {
   TabsModule,
   SelectMenuModule,
   AlertModule,
+  TextareaModule,
 } from '@oort-front/ui';
 
 /**
@@ -45,6 +46,7 @@ import {
     DividerModule,
     TabsModule,
     AlertModule,
+    TextareaModule,
   ],
   exports: [ButtonConfigComponent],
 })

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -71,6 +71,7 @@ export const createButtonFormGroup = (value: any) => {
     autoSave: [value && value.autoSave ? value.autoSave : false],
     modifySelectedRows: [value ? value.modifySelectedRows : false],
     requireConfirmation: [value ? value.requireConfirmation : false],
+    modifyConfirmationText: [value?.modifyConfirmationText ?? ''],
     modifications: fb.array(
       value && value.modifications && value.modifications.length
         ? value.modifications.map((x: any) =>

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -562,8 +562,13 @@ export class GridWidgetComponent
           ? firstValueFrom(
               this.confirmService.openConfirmModal({
                 title: this.translate.instant(
-                  'components.widget.settings.chart.grid.buttons.modifySelectedRows.confirmation'
+                  'components.widget.settings.grid.buttons.confirmation.title'
                 ),
+                content:
+                  options.modifyConfirmationText ||
+                  this.translate.instant(
+                    'components.widget.settings.grid.buttons.confirmation.defaultText'
+                  ),
                 confirmText: this.translate.instant(
                   'components.confirmModal.confirm'
                 ),


### PR DESCRIPTION

# Description

This PR makes it so now you can set the confirmation prompt text on the auto-modify button in a gird widget.

## Useful links

- Please insert link to ticket   https://www.notion.so/Confirm-prompt-when-submitting-form-1aed463fd8c480a2a01bccc6fed429f7?pvs=4


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
