### PR TITLE
MAB-249 order dynamic panels

### DIFF
--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -10,6 +10,7 @@ import {
   DownloadFileEvent,
   UploadFilesEvent,
   PanelModelBase,
+  QuestionPanelDynamicModel,
 } from 'survey-core';
 import { ReferenceDataService } from '../reference-data/reference-data.service';
 import { renderGlobalProperties } from '../../survey/render-global-properties';
@@ -307,6 +308,11 @@ export class FormBuilderService {
       const questionType = options.question.getType();
       switch (questionType) {
         case 'paneldynamic':
+          this.formHelpersService.addUploadButton(options);
+          this.formHelpersService.orderDynamicPanels(
+            options.question as QuestionPanelDynamicModel
+          );
+          break;
         case 'matrixdynamic':
           this.formHelpersService.addUploadButton(options);
           break;

--- a/libs/shared/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/shared/src/lib/services/form-helper/form-helper.service.ts
@@ -1074,6 +1074,28 @@ export class FormHelpersService {
   }
 
   /**
+   * Sorts dynamic panels by a subquestion
+   *
+   * @param question Question to sort
+   */
+  public orderDynamicPanels(question: QuestionPanelDynamicModel): void {
+    const { sortBySubQuestion, sortDirection } = question;
+    if (sortBySubQuestion && question.value) {
+      const initPanels = question.value;
+      const sorted: Record<string, any>[] = cloneDeep(initPanels ?? []);
+
+      sorted.sort((a, b) => {
+        const aValue = get(a, sortBySubQuestion)?.toString() ?? '';
+        const bValue = get(b, sortBySubQuestion)?.toString() ?? '';
+        return sortDirection === 'asc'
+          ? aValue.localeCompare(bValue)
+          : bValue.localeCompare(aValue);
+      });
+      question.value = sorted;
+    }
+  }
+
+  /**
    * Set download listener for files in the survey
    *
    * @param e Event raised after rendering a question

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -269,6 +269,48 @@ export const init = (environment: any): void => {
     default: false,
   });
 
+  // Sort panels by sub-question value
+  serializer.addProperty('paneldynamic', {
+    name: 'sortBySubQuestion:dropdown',
+    category: 'general',
+    choices: (
+      obj: null | QuestionPanelDynamicModel,
+      choicesCallback: (choices: any[]) => void
+    ) => {
+      if (!obj) {
+        choicesCallback([]);
+        return;
+      }
+
+      const choices = obj.templateElements.map((el) => {
+        const title = 'title' in el ? el.title : '';
+        return {
+          value: el.name,
+          text: title || el.name,
+        };
+      });
+      choicesCallback(choices);
+    },
+  });
+
+  // if the sortBySubQuestion is set, display the sort direction
+  serializer.addProperty('paneldynamic', {
+    name: 'sortDirection:dropdown',
+    category: 'general',
+    choices: [
+      {
+        value: 'asc',
+        text: 'Ascending',
+      },
+      {
+        value: 'desc',
+        text: 'Descending',
+      },
+    ],
+    default: 'asc',
+    visibleIf: (obj: QuestionPanelDynamicModel) => !!obj.sortBySubQuestion,
+  });
+
   const allowImportProp = {
     name: 'allowImport:boolean',
     default: false,


### PR DESCRIPTION
# Description

This PR adds an option to dynamic panels to sort by subquestion value. It's only triggered when updating a record. 

## Useful links

- Please insert link to ticket https://www.notion.so/Order-comments-1afd463fd8c4801f9276cacdd2de9634?pvs=4

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Comments on the platform are now sorted by question.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
