### PR TITLE
HIT-451 Take inline button in consideration for columns width calcula…

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -1065,6 +1065,10 @@ export class GridComponent
     if (this.selectable) {
       totalWidthSticky += 41;
     }
+    // ADD THIS BLOCK: include inline action button column width if present
+    if (this.inlineActionButtons.length > 0) {
+      totalWidthSticky += this.floatingButtonsWidth;
+    }
     // Hide the columns that are hidden by default
     const hiddenFields = this.fields.filter((field) => field.hiddenByDefault);
     hiddenFields.forEach((field) => {
@@ -1298,6 +1302,10 @@ export class GridComponent
         column.width = MIN_COLUMN_WIDTH;
       }
     });
+
+    if (this.inlineActionButtons.length > 0) {
+      totalWidthSticky += this.floatingButtonsWidth;
+    }
   }
 
   /** Restore all columns visibility and size when reset the layout of the grid */


### PR DESCRIPTION
…tion

# Description
Updated column width logic in grid.component.ts to consider inline buttons
## Useful links

https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-451

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x ] * I have set myself as assignee of the pull request
- [ x] * My code follows the style guidelines of this project
- [ x] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [x ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
