### PR TITLE
MAB-462: Cannot see full text on many dropdowns

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -10,6 +10,7 @@ import {
   SurveyModel,
   PageModel,
   surveyLocalization,
+  MatrixDropdownColumn,
 } from 'survey-core';
 import { MatrixManager } from '../controllers/matrixManager';
 import { CustomPropertyGridComponentTypes } from '../components/utils/components.enum';
@@ -35,6 +36,60 @@ export const init = (environment: any): void => {
     category: 'general',
     isRequired: true,
   });
+
+  const showReducedOptionsDropdown = (obj: Question | null): boolean => {
+    if (!obj) {
+      return false;
+    }
+    const type = obj.getType?.() || '';
+    return type === 'dropdown' || type === 'tagbox';
+  };
+
+  const showReducedOptionsMatrices = (obj: any): boolean => {
+    if (!obj) {
+      return false;
+    }
+    const column: MatrixDropdownColumn | undefined =
+      (obj as MatrixDropdownColumn).cellType !== undefined
+        ? (obj as MatrixDropdownColumn)
+        : (obj.locOwner as MatrixDropdownColumn | undefined);
+
+    if (!column) {
+      return false;
+    }
+
+    const owner = (column as any).colOwnerValue;
+    const columnCellType = column.cellType as string;
+    const matrixCellType = owner?.cellType as string | undefined;
+
+    const effectiveType =
+      columnCellType && columnCellType !== 'default'
+        ? columnCellType
+        : matrixCellType || '';
+
+    return effectiveType === 'dropdown' || effectiveType === 'tagbox';
+  };
+
+  // Controls Kendo virtualization for select-based questions (dropdown, tagbox, etc.)
+  serializer.addProperty('selectbase', {
+    name: 'showReducedOptions:boolean',
+    category: 'general',
+    visibleIndex: 9,
+    default: false,
+    showMode: 'form',
+    visibleIf: (obj: Question | null) => showReducedOptionsDropdown(obj),
+  });
+
+  // Controls Kendo virtualization for dropdown / tagbox cells inside matrix questions
+  serializer.addProperty('matrixdropdowncolumn', {
+    name: 'showReducedOptions:boolean',
+    category: 'general',
+    visibleIndex: 8,
+    default: false,
+    showMode: 'form',
+    visibleIf: (obj: any) => showReducedOptionsMatrices(obj),
+  });
+
   // Pass token before the request to fetch choices by URL if it's targeting SHARED API
   ChoicesRestful.onBeforeSendRequest = (
     sender: ChoicesRestful,

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -37,7 +37,7 @@ export const init = (environment: any): void => {
     isRequired: true,
   });
 
-  const showReducedOptionsDropdown = (obj: Question | null): boolean => {
+  const useVirtualizationDropdown = (obj: Question | null): boolean => {
     if (!obj) {
       return false;
     }
@@ -45,7 +45,7 @@ export const init = (environment: any): void => {
     return type === 'dropdown' || type === 'tagbox';
   };
 
-  const showReducedOptionsMatrices = (obj: any): boolean => {
+  const useVirtualizationMatrices = (obj: any): boolean => {
     if (!obj) {
       return false;
     }
@@ -72,22 +72,22 @@ export const init = (environment: any): void => {
 
   // Controls Kendo virtualization for select-based questions (dropdown, tagbox, etc.)
   serializer.addProperty('selectbase', {
-    name: 'showReducedOptions:boolean',
+    name: 'useVirtualization:boolean',
     category: 'general',
     visibleIndex: 9,
     default: false,
     showMode: 'form',
-    visibleIf: (obj: Question | null) => showReducedOptionsDropdown(obj),
+    visibleIf: (obj: Question | null) => useVirtualizationDropdown(obj),
   });
 
   // Controls Kendo virtualization for dropdown / tagbox cells inside matrix questions
   serializer.addProperty('matrixdropdowncolumn', {
-    name: 'showReducedOptions:boolean',
+    name: 'useVirtualization:boolean',
     category: 'general',
     visibleIndex: 8,
     default: false,
     showMode: 'form',
-    visibleIf: (obj: any) => showReducedOptionsMatrices(obj),
+    visibleIf: (obj: any) => useVirtualizationMatrices(obj),
   });
 
   // Pass token before the request to fetch choices by URL if it's targeting SHARED API

--- a/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
@@ -174,13 +174,11 @@ export const init = (
       element
     );
     const dropdownInstance: ComboBoxComponent = dropdown.instance;
-    const showReducedOptions =
-      (question as unknown as QuestionSelectBase).showReducedOptions === true;
-    dropdownInstance.virtual = showReducedOptions
-      ? {
-          itemHeight: 28,
-        }
-      : false;
+    const useVirtualization =
+      (question as unknown as QuestionSelectBase).useVirtualization === true;
+    if (useVirtualization) {
+      dropdownInstance.virtual = { itemHeight: 28 };
+    }
     dropdownInstance.valuePrimitive = Boolean(question.isPrimitiveValue);
     dropdownInstance.filterable = true;
     dropdownInstance.loading = true;
@@ -189,7 +187,7 @@ export const init = (
     dropdownInstance.valueField = 'value';
     dropdownInstance.popupSettings = {
       appendTo: 'component',
-      width: showReducedOptions
+      width: useVirtualization
         ? question.popupWidth
         : question.popupWidth || 'auto',
     };

--- a/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
@@ -174,9 +174,13 @@ export const init = (
       element
     );
     const dropdownInstance: ComboBoxComponent = dropdown.instance;
-    dropdownInstance.virtual = {
-      itemHeight: 28,
-    };
+    const showReducedOptions =
+      (question as unknown as QuestionSelectBase).showReducedOptions === true;
+    dropdownInstance.virtual = showReducedOptions
+      ? {
+          itemHeight: 28,
+        }
+      : false;
     dropdownInstance.valuePrimitive = Boolean(question.isPrimitiveValue);
     dropdownInstance.filterable = true;
     dropdownInstance.loading = true;
@@ -185,7 +189,9 @@ export const init = (
     dropdownInstance.valueField = 'value';
     dropdownInstance.popupSettings = {
       appendTo: 'component',
-      width: question.popupWidth,
+      width: showReducedOptions
+        ? question.popupWidth
+        : question.popupWidth || 'auto',
     };
     // Automatic display of dropdown panel on element focus by default
     dropdownInstance.wrapper.nativeElement

--- a/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
@@ -253,13 +253,13 @@ export const init = (
       element
     );
     const tagboxInstance: MultiSelectComponent = tagbox.instance;
-    const showReducedOptions =
-      (question as unknown as any).showReducedOptions === true;
-    tagboxInstance.virtual = showReducedOptions
-      ? {
-          itemHeight: 28,
-        }
-      : false;
+    const useVirtualization =
+      (question as unknown as any).useVirtualization === true;
+    if (useVirtualization) {
+      tagboxInstance.virtual = {
+        itemHeight: 28,
+      };
+    }
     tagboxInstance.valuePrimitive = Boolean(question.isPrimitiveValue);
     tagboxInstance.filterable = true;
     tagboxInstance.loading = true;
@@ -268,7 +268,7 @@ export const init = (
     tagboxInstance.valueField = 'value';
     tagboxInstance.popupSettings = {
       appendTo: 'component',
-      width: showReducedOptions
+      width: useVirtualization
         ? question.popupWidth
         : question.popupWidth || 'auto',
     };

--- a/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
@@ -253,9 +253,13 @@ export const init = (
       element
     );
     const tagboxInstance: MultiSelectComponent = tagbox.instance;
-    tagboxInstance.virtual = {
-      itemHeight: 28,
-    };
+    const showReducedOptions =
+      (question as unknown as any).showReducedOptions === true;
+    tagboxInstance.virtual = showReducedOptions
+      ? {
+          itemHeight: 28,
+        }
+      : false;
     tagboxInstance.valuePrimitive = Boolean(question.isPrimitiveValue);
     tagboxInstance.filterable = true;
     tagboxInstance.loading = true;
@@ -264,7 +268,9 @@ export const init = (
     tagboxInstance.valueField = 'value';
     tagboxInstance.popupSettings = {
       appendTo: 'component',
-      width: question.popupWidth,
+      width: showReducedOptions
+        ? question.popupWidth
+        : question.popupWidth || 'auto',
     };
     tagboxInstance.fillMode = 'none';
     if (question.useSummaryTagMode) {

--- a/libs/shared/src/typings/survey-core/index.d.ts
+++ b/libs/shared/src/typings/survey-core/index.d.ts
@@ -27,6 +27,7 @@ declare module 'survey-core' {
     referenceDataFilterFilterCondition?: string;
     referenceDataFilterLocalField?: string;
     referenceDataChoicesLoaded?: boolean;
+    showReducedOptions?: boolean;
   }
 
   // Augmenting MatrixDropdownColumn from survey-core
@@ -39,6 +40,7 @@ declare module 'survey-core' {
     referenceDataFilterFilterCondition?: string;
     referenceDataFilterLocalField?: string;
     referenceDataChoicesLoaded?: boolean;
+    showReducedOptions?: boolean;
   }
 
   interface QuestionUsers extends QuestionCustomModel {

--- a/libs/shared/src/typings/survey-core/index.d.ts
+++ b/libs/shared/src/typings/survey-core/index.d.ts
@@ -27,7 +27,7 @@ declare module 'survey-core' {
     referenceDataFilterFilterCondition?: string;
     referenceDataFilterLocalField?: string;
     referenceDataChoicesLoaded?: boolean;
-    showReducedOptions?: boolean;
+    useVirtualization?: boolean;
   }
 
   // Augmenting MatrixDropdownColumn from survey-core
@@ -40,7 +40,7 @@ declare module 'survey-core' {
     referenceDataFilterFilterCondition?: string;
     referenceDataFilterLocalField?: string;
     referenceDataChoicesLoaded?: boolean;
-    showReducedOptions?: boolean;
+    useVirtualization?: boolean;
   }
 
   interface QuestionUsers extends QuestionCustomModel {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oort-front",
-  "version": "1.0.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oort-front",
-      "version": "1.0.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",


### PR DESCRIPTION
# Description

Fix to be able to see full text on many dropdowns and tag boxes.

## Useful links

Link to ticket: https://www.notion.so/Cannot-see-full-text-on-many-dropdowns-25bd463fd8c4803b918cf945e04f124e?source=copy_link

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
