### PR TITLE
MAB-560: Percentage value sometimes changing for no reason

### DIFF
--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -116,7 +116,7 @@ export const transformSurveyData = (survey: SurveyModel) => {
   });
   if (survey.showPercentageProgressBar) {
     // isRequiredCpy is declared in the form builder service, and copy the isRequired property of the question we build when using skipRequiredValidation
-    // getVisibleQuestions is too slow. Now, we prevent _progress from becoming NaN, resulting in division by 0, or requiredQuestions.length from having sudden changes.
+    // By using getVisibleQuestions, _progress used only currently visible questions, its denominator changed as visibility changed, even when answers didn’t.
     const requiredQuestions = survey
       .getAllQuestions()
       .filter(

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -116,14 +116,20 @@ export const transformSurveyData = (survey: SurveyModel) => {
   });
   if (survey.showPercentageProgressBar) {
     // isRequiredCpy is declared in the form builder service, and copy the isRequired property of the question we build when using skipRequiredValidation
-    const requiredQuestions = getVisibleQuestions(
-      survey.getAllQuestions(true)
-    ).filter((q) => q.isRequired || q.isRequiredCpy);
-    data._progress =
-      (requiredQuestions.filter((question: Question) => !question.isEmpty())
-        .length *
-        100) /
-      requiredQuestions.length;
+    // getVisibleQuestions is too slow. Now, we prevent _progress from becoming NaN, resulting in division by 0, or requiredQuestions.length from having sudden changes.
+    const requiredQuestions = survey
+      .getAllQuestions()
+      .filter(
+        (q) => (q.isRequired || q.isRequiredCpy) && !q.readOnly && q.hasInput
+      );
+
+    if (requiredQuestions.length) {
+      data._progress =
+        (requiredQuestions.filter((question: Question) => !question.isEmpty())
+          .length *
+          100) /
+        requiredQuestions.length;
+    }
   }
   return data;
 };

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -115,13 +115,10 @@ export const transformSurveyData = (survey: SurveyModel) => {
     }
   });
   if (survey.showPercentageProgressBar) {
-    // isRequiredCpy is declared in the form builder service, and copy the isRequired property of the question we build when using skipRequiredValidation
-    // By using getVisibleQuestions, _progress used only currently visible questions, its denominator changed as visibility changed, even when answers didn’t.
+    // Filter only required questions that are not read-only and have input
     const requiredQuestions = survey
       .getAllQuestions()
-      .filter(
-        (q) => (q.isRequired || q.isRequiredCpy) && !q.readOnly && q.hasInput
-      );
+      .filter((q) => q.isRequired && !q.readOnly && q.hasInput);
 
     if (requiredQuestions.length) {
       data._progress =

--- a/libs/shared/src/lib/survey/progress-bar/progress-bar.component.ts
+++ b/libs/shared/src/lib/survey/progress-bar/progress-bar.component.ts
@@ -31,11 +31,10 @@ export class ProgressBarComponent implements OnInit {
 
   ngOnInit() {
     this.title = this.model.data.form_and_br;
-    // isRequiredCpy is declared in the form builder service, and copy the isRequired property of the question we build when using skipRequiredValidation
     const updateCurrentPageQuestions = () => {
       this.currentPageRequiredQuestions = getVisibleQuestions(
         this.model.currentPage.questions
-      ).filter((q) => q.isRequired || q.isRequiredCpy);
+      ).filter((q) => q.isRequired && q.hasInput);
       this.updateValue();
     };
     updateCurrentPageQuestions();


### PR DESCRIPTION
# Description

Fix so that the percentage value stops changing for no reason. 

In summary, the issue was happening because _progress was calculated from currently visible questions using the getVisibleQuestions functions, so any changes in visibility (pages, conditions, dynamic panels) altered the denominator between saves. It would sometimes create sudden changes or even NaN results.

## Useful links

Link to ticket: https://www.notion.so/Percentage-value-sometimes-changing-for-no-reason-2b5d463fd8c4804a868bc973238355ed?source=copy_link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
