### PR TITLE
MAB-539 Remove “Go to application” from external user views

### DIFF
--- a/libs/shared/src/lib/components/layout/layout.component.html
+++ b/libs/shared/src/lib/components/layout/layout.component.html
@@ -72,7 +72,7 @@
         {{ 'components.preferences.title' | translate }}
       </button>
     </ng-container>
-    <ng-container *ngIf="applications && applications.length > 0">
+    <ng-container *ngIf="applications && applications.length > 0 && environment.module === 'backoffice'">
       <ui-divider class="py-1"></ui-divider>
       <button
         uiMenuItem

--- a/libs/shared/src/lib/components/layout/layout.component.html
+++ b/libs/shared/src/lib/components/layout/layout.component.html
@@ -63,15 +63,18 @@
   <!-- Notification button -->
   <shared-notification-button></shared-notification-button>
   <ui-menu #accountMenu>
+    <!-- Open user profile -->
     <a uiMenuItem [routerLink]="[profileRoute]">
       {{ 'pages.profile.title' | translate }}
     </a>
+    <!-- User preferences -->
     <ng-container *ngIf="showPreferences">
       <ui-divider class="py-1"></ui-divider>
       <button uiMenuItem (click)="onOpenPreferences()">
         {{ 'components.preferences.title' | translate }}
       </button>
     </ng-container>
+    <!-- Application switch, hidden in front-office -->
     <ng-container *ngIf="applications && applications.length > 0 && environment.module === 'backoffice'">
       <ui-divider class="py-1"></ui-divider>
       <button
@@ -94,6 +97,7 @@
         ></shared-search-menu>
       </ng-template>
     </ng-container>
+    <!-- Go to other office -->
     <ng-container *ngIf="user && user.isAdmin">
       <ui-divider class="py-1"></ui-divider>
       <a uiMenuItem [href]="otherOfficeUri">
@@ -101,6 +105,7 @@
       </a>
     </ng-container>
     <ui-divider class="py-1"></ui-divider>
+    <!-- Logout -->
     <button uiMenuItem class="text-red-500" (click)="logout()">
       {{ 'components.header.logout' | translate }}
     </button>


### PR DESCRIPTION
# Description

This change hides the "Go to application" button from the user dropdown menu when the application is running in front-office mode. The implementation adds a simple conditional check (`environment.module === 'backoffice'`) to the existing `*ngIf` directive in the layout component template, ensuring the button only renders in the back-office environment.

## Useful links

- **Ticket:** https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2a5d463fd8c480fa9ed8f61e00bd47a4&pm=s

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

**Test A: Front-Office - Button Hidden**
  1. Run `npx nx run front-office:serve`
  2. Log in
  3. Click the account icon (top-right corner)
  4. **Expected:** "Go to application" button is NOT visible in the dropdown menu
  
- **Test B: Back-Office - Button Visible**
  1. Run `npx nx run back-office:serve`
  2. Log in
  3. Click the account icon (top-right corner)
  4. **Expected:** "Go to application" button IS visible in the dropdown menu

## Screenshots

<img width="332" height="256" alt="Screenshot from 2025-11-30 12-36-55" src="https://github.com/user-attachments/assets/4e2c17c2-1942-453d-9419-88584e220259" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
