### PR TITLE
MAB-540 Remove “create a new record” after BR submissions

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -890,7 +890,7 @@
       },
       "display": {
         "cancelMessage": "Operation canceled",
-        "submissionMessage": "The form has successfully been submitted."
+        "submissionMessage": "Thank you for submitting"
       },
       "draftRecords": {
         "buttonLoad": "Load draft record",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -890,7 +890,7 @@
       },
       "display": {
         "cancelMessage": "Operation canceled",
-        "submissionMessage": "Thank you for submitting"
+        "submissionMessage": "Thank you for submitting."
       },
       "draftRecords": {
         "buttonLoad": "Load draft record",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -901,7 +901,7 @@
       },
       "display": {
         "cancelMessage": "Opération annulée",
-        "submissionMessage": "Merci pour votre soumission"
+        "submissionMessage": "Votre réponse a bien été enregistrée."
       },
       "draftRecords": {
         "buttonLoad": "Charger un brouillon",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -901,7 +901,7 @@
       },
       "display": {
         "cancelMessage": "Opération annulée",
-        "submissionMessage": "Le formulaire a été sauvegardé."
+        "submissionMessage": "Merci pour votre soumission"
       },
       "draftRecords": {
         "buttonLoad": "Charger un brouillon",

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -325,20 +325,16 @@ export class FormModalComponent
    * Initializes the form
    */
   private initSurvey(): void {
-    // Override completedHtml in structure before creating survey
-    const formStructure = JSON.parse(this.form?.structure || '{}');
-    if (formStructure) {
-      formStructure.completedHtml = `<h3>${this.translate.instant(
-        'components.form.display.submissionMessage'
-      )}</h3>`;
-    }
-
     this.survey = this.formBuilderService.createSurvey(
-      JSON.stringify(formStructure),
+      this.form?.structure || '',
       this.form?.metadata,
       this.record,
       this.form
     );
+    // Override completedHtml in structure
+    this.survey.completedHtml = `<h3>${this.translate.instant(
+      'components.form.display.submissionMessage'
+    )}</h3>`;
     // After the survey is created we add common callback to survey events
     this.formBuilderService.addEventsCallBacksToSurvey(
       this.survey,
@@ -965,8 +961,14 @@ export class FormModalComponent
       );
     } else if (data) {
       if (this.submitting) {
-        // Form was submitted, show completion page instead of closing dialog
-        this.survey.showCompletedPage = true;
+        // Form was submitted, show submission message & close dialog
+        this.snackBar.openSnackBar(
+          this.translate.instant('components.form.display.submissionMessage')
+        );
+        this.closeDialog({
+          template: this.form?.id,
+          data: data[responseType],
+        } as any);
       } else {
         if (!this.autosaving) {
           // Form is not in autosave mode

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -325,8 +325,16 @@ export class FormModalComponent
    * Initializes the form
    */
   private initSurvey(): void {
+    // Override completedHtml in structure before creating survey
+    const formStructure = JSON.parse(this.form?.structure || '{}');
+    if (formStructure) {
+      formStructure.completedHtml = `<h3>${this.translate.instant(
+        'components.form.display.submissionMessage'
+      )}</h3>`;
+    }
+
     this.survey = this.formBuilderService.createSurvey(
-      this.form?.structure || '',
+      JSON.stringify(formStructure),
       this.form?.metadata,
       this.record,
       this.form
@@ -957,14 +965,8 @@ export class FormModalComponent
       );
     } else if (data) {
       if (this.submitting) {
-        // Form was submitted, show submission message & close dialog
-        this.snackBar.openSnackBar(
-          this.translate.instant('components.form.display.submissionMessage')
-        );
-        this.closeDialog({
-          template: this.form?.id,
-          data: data[responseType],
-        } as any);
+        // Form was submitted, show completion page instead of closing dialog
+        this.survey.showCompletedPage = true;
       } else {
         if (!this.autosaving) {
           // Form is not in autosave mode

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -483,7 +483,7 @@ export class FormComponent
 
                 this.save.emit({
                   completed: true,
-                  hideNewRecord: true, // Hide new record button after submission
+                  hideNewRecord: true, // Always hide new record button after submission
                 });
               }
 
@@ -723,6 +723,7 @@ export class FormComponent
       });
     }
 
+    // Auto save survey
     if (this.survey.autoSave && this.survey.mode !== 'display') {
       this.autoSaveInterval = interval(15000)
         .pipe(takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -475,6 +475,7 @@ export class FormComponent
                   } else if (data.editRecord) {
                     this.modifiedAt = data.editRecord.modifiedAt;
                   }
+                  this.survey.showCompletedPage = true; // Show completion message after Save & Submit
                   this.surveyActive = true;
                 } else {
                   this.survey.showCompletedPage = true;
@@ -482,9 +483,7 @@ export class FormComponent
 
                 this.save.emit({
                   completed: true,
-                  hideNewRecord: autoSave
-                    ? true
-                    : data.addRecord && data.addRecord.form.uniqueRecord,
+                  hideNewRecord: true, // Hide new record button after submission
                 });
               }
 
@@ -638,11 +637,8 @@ export class FormComponent
     });
 
     const structure = JSON.parse(this.form.structure || '{}');
-    if (
-      structure &&
-      !structure.completedHtml &&
-      !structure.completedHtmlOnCondition
-    ) {
+    // Override completedHtml with standard message
+    if (structure) {
       structure.completedHtml = `<h3>${this.translate.instant(
         'components.form.display.submissionMessage'
       )}</h3>`;
@@ -727,7 +723,6 @@ export class FormComponent
       });
     }
 
-    // Auto save survey
     if (this.survey.autoSave && this.survey.mode !== 'display') {
       this.autoSaveInterval = interval(15000)
         .pipe(takeUntil(this.destroy$))


### PR DESCRIPTION
# Description

Updated the form submission behavior for Biosphere Reserve (BR) forms to improve user experience after form submission. This change replaces the default "create a new record" prompt with a "Thank you for submitting" message and prevents the new record button from appearing after submission.

## Useful links

- **Ticket** : https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2a6d463fd8c480d1b47ef3a11fcb056e&pm=s

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Tested BR form submission with "Save and Submit" button
- Verified completion message displays correctly in both English and French
- Confirmed "new record" button no longer appears after submission
- Tested with autosave temporarily disabled to verify behavior
- Verified completion page remains visible in modal after submission

## Screenshots

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
