### PR TITLE
MAB-577 - Remove duplicate form load in form page

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -229,7 +229,9 @@ export class FormComponent
   }
 
   ngOnInit(): void {
-    this.initSurvey();
+    if (!this.record) {
+      this.initSurvey();
+    }
   }
 
   /** Sets up listeners to keep mapped fields updated */
@@ -607,6 +609,8 @@ export class FormComponent
    * fetches cached data from local storage, and sets the lookup data.
    */
   private initSurvey(): void {
+    this.survey?.dispose();
+
     addCustomFunctions({
       record: this.record,
       authService: this.authService,

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -222,16 +222,15 @@ export class FormComponent
   ngOnChanges(changes: SimpleChanges): void {
     if (
       changes.record &&
-      changes.record.currentValue?.id !== changes.record.previousValue?.id
+      changes.record.currentValue?.id !== changes.record.previousValue?.id &&
+      changes.record.previousValue !== undefined
     ) {
       this.initSurvey();
     }
   }
 
   ngOnInit(): void {
-    if (!this.record) {
-      this.initSurvey();
-    }
+    this.initSurvey();
   }
 
   /** Sets up listeners to keep mapped fields updated */


### PR DESCRIPTION
# Description

This PR fixes a double initialization issue in the form component that occurred when a record was provided as input. Previously, initSurvey() was called both in ngOnInit() and ngOnChanges(), causing unnecessary re-initialization and potential performance issues.

Changes made:

 - Added conditional check in ngOnInit() to only call initSurvey() when no record input is provided
 - Added this.survey?.dispose() at the beginning of initSurvey() to properly clean up previous survey instances before creating new ones
 
This ensures that:

 - When a record is provided, initialization happens only once via ngOnChanges()
 - When no record is provided, initialization happens only once via ngOnInit()
 - Previous survey instances are properly disposed to prevent memory leaks

## Useful links

- ticket: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2c5d463fd8c48072bd5cd3c31e4f62d9&pm=s

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The changes have been tested through:

 - Manual testing with console logs: Added temporary logs to verify initSurvey() is called only once in both scenarios (with and without record input)
 - Browser DevTools inspection: Verified that survey.dispose() is called before creating new survey instances
 - Form loading with existing record: Confirmed form loads correctly with data and initializes only once
 - Form loading without record: Confirmed empty form initializes only once

## Screenshots

N/A

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
