### PR TITLE
MAB-321 Add word count validator for tinymce questions in surveyjs

### DIFF
--- a/libs/shared/src/lib/components/editor-question/editor-question.component.html
+++ b/libs/shared/src/lib/components/editor-question/editor-question.component.html
@@ -2,5 +2,12 @@
   #editor
   [readonly]="readonly"
   [editorConfig]="config"
-  (editorLoaded)="editorLoaded.emit(true);"
-></shared-editor-control>
+  (editorLoaded)="editorLoaded.emit(true)">
+</shared-editor-control>
+
+<div class="text-sm text-gray-600 mt-1" *ngIf="maxWords > 0">
+  {{ wordCount }} / {{ maxWords }} words
+  <span class="text-red-600 font-semibold" *ngIf="wordCount > maxWords">
+    ({{ wordCount - maxWords }} over limit)
+  </span>
+</div>

--- a/libs/shared/src/lib/components/editor-question/editor-question.component.html
+++ b/libs/shared/src/lib/components/editor-question/editor-question.component.html
@@ -2,7 +2,8 @@
   #editor
   [readonly]="readonly"
   [editorConfig]="config"
-  (editorLoaded)="editorLoaded.emit(true)">
+  (editorLoaded)="editorLoaded.emit(true)"
+>
 </shared-editor-control>
 
 <div class="text-sm text-gray-600 mt-1" *ngIf="maxWords > 0">

--- a/libs/shared/src/lib/components/editor-question/editor-question.component.ts
+++ b/libs/shared/src/lib/components/editor-question/editor-question.component.ts
@@ -6,6 +6,7 @@ import {
   Input,
   ViewChild,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { EditorControlComponent } from '../controls/public-api';
 import { BehaviorSubject } from 'rxjs';
 import { RawEditorOptions } from 'tinymce';
@@ -14,13 +15,15 @@ import { RawEditorOptions } from 'tinymce';
 @Component({
   selector: 'app-editor-question',
   standalone: true,
-  imports: [EditorControlComponent],
+  imports: [EditorControlComponent, CommonModule],
   templateUrl: './editor-question.component.html',
   styleUrls: ['./editor-question.component.scss'],
 })
 export class EditorQuestionComponent implements AfterViewInit {
   /** Is readonly */
   @Input() readonly = false;
+  /** max words limit */
+  @Input() maxWords = -1;
   /** configuration of the editor */
   @Input() config!: RawEditorOptions;
   /** editor */
@@ -28,6 +31,8 @@ export class EditorQuestionComponent implements AfterViewInit {
   public editor!: EditorControlComponent;
   /** html content */
   public html = new BehaviorSubject<string | undefined>(undefined);
+  /** word count*/
+  public wordCount = 0;
   /** editor loaded */
   public editorLoaded = new EventEmitter<boolean>();
 
@@ -40,7 +45,22 @@ export class EditorQuestionComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.editor.registerOnChange(() => {
-      this.html.next(this.editor.editor.editor.getContent());
+      const content = this.editor.editor.editor.getContent();
+      this.html.next(content);
+      if (this.maxWords > 0) {
+        let text = content.replace(
+          /<\/?(div|p|li|ul|ol|br|h[1-6]|table|tr|td|th|pre|blockquote)[^>]*>/gi,
+          ' '
+        );
+        text = text.replace(/<[^>]+>/g, '');
+        text = text.replace(/&nbsp;/g, ' ');
+        this.wordCount = text.trim()
+          ? text
+              .trim()
+              .split(/\s+/)
+              .filter((w) => w.length > 0).length
+          : 0;
+      }
     });
   }
 }

--- a/libs/shared/src/lib/components/editor-question/editor-question.component.ts
+++ b/libs/shared/src/lib/components/editor-question/editor-question.component.ts
@@ -45,22 +45,18 @@ export class EditorQuestionComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.editor.registerOnChange(() => {
+      this.wordCount = this.getWordCount();
       const content = this.editor.editor.editor.getContent();
       this.html.next(content);
-      if (this.maxWords > 0) {
-        let text = content.replace(
-          /<\/?(div|p|li|ul|ol|br|h[1-6]|table|tr|td|th|pre|blockquote)[^>]*>/gi,
-          ' '
-        );
-        text = text.replace(/<[^>]+>/g, '');
-        text = text.replace(/&nbsp;/g, ' ');
-        this.wordCount = text.trim()
-          ? text
-              .trim()
-              .split(/\s+/)
-              .filter((w) => w.length > 0).length
-          : 0;
-      }
     });
+  }
+
+  /**
+   * Get word count
+   *
+   * @returns number of words
+   */
+  public getWordCount(): number {
+    return this.editor?.editor.editor.plugins.wordcount.getCount() || 0;
   }
 }

--- a/libs/shared/src/lib/survey/components/editor.ts
+++ b/libs/shared/src/lib/survey/components/editor.ts
@@ -3,6 +3,7 @@ import {
   Serializer,
   SvgRegistry,
   Question,
+  CustomError,
 } from 'survey-core';
 import { DomService } from '../../services/dom/dom.service';
 import { EditorQuestionComponent } from '../../components/editor-question/editor-question.component';
@@ -11,6 +12,29 @@ import { Injector } from '@angular/core';
 import { FIELD_EDITOR_CONFIG } from '../../const/tinymce.const';
 import { EditorService } from '../../services/editor/editor.service';
 import { CustomPropertyGridComponentTypes } from './utils/components.enum';
+
+/**
+ * Helper function to count words consistently
+ * 1. Replaces Block tags (p, div, br, etc) with SPACE.
+ * 2. Replaces Inline tags (strong, span, etc) with EMPTY STRING.
+ * 3. Handles &nbsp;
+ *
+ * @param html
+ */
+const calculateWordCount = (html: string): number => {
+  if (!html) return 0;
+  let text = html;
+  text = text.replace(
+    /<\/?(div|p|li|ul|ol|br|h[1-6]|table|tr|td|th|pre|blockquote)[^>]*>/gi,
+    ' '
+  );
+  text = text.replace(/<[^>]+>/g, '');
+  text = text.replace(/&nbsp;/g, ' ');
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter((w) => w.length > 0).length;
+};
 
 /**
  * Inits the editor component.
@@ -49,6 +73,12 @@ export const init = (
         category: 'Editor configuration',
         visibleIndex: 1,
         default: JSON.stringify(cloneDeep(FIELD_EDITOR_CONFIG)),
+      });
+      Serializer.addProperty('editor', {
+        name: 'maxWords:number',
+        category: 'general',
+        default: -1,
+        visibleIndex: 2,
       });
       return;
     },
@@ -95,6 +125,7 @@ export const init = (
           editable_root: false,
         }),
       };
+      instance.maxWords = question.maxWords || -1;
       instance.cdr.detectChanges();
 
       // Set readonly mode of instance based on readonly & survey mode
@@ -114,6 +145,19 @@ export const init = (
         instance.html.subscribe((html) => {
           if (isNil(html)) {
             return;
+          }
+          if (question.maxWords && question.maxWords > 0) {
+            const wordCount = calculateWordCount(html);
+            if (wordCount > question.maxWords) {
+              question.addError(
+                new CustomError(
+                  `Maximum word limit is ${question.maxWords}. Current: ${wordCount}`,
+                  question
+                )
+              );
+            } else {
+              question.clearErrors();
+            }
           }
           if (question.survey?.isDesignMode) {
             question.defaultValue = html;

--- a/libs/shared/src/lib/survey/components/editor.ts
+++ b/libs/shared/src/lib/survey/components/editor.ts
@@ -14,29 +14,6 @@ import { EditorService } from '../../services/editor/editor.service';
 import { CustomPropertyGridComponentTypes } from './utils/components.enum';
 
 /**
- * Helper function to count words consistently
- * 1. Replaces Block tags (p, div, br, etc) with SPACE.
- * 2. Replaces Inline tags (strong, span, etc) with EMPTY STRING.
- * 3. Handles &nbsp;
- *
- * @param html
- */
-const calculateWordCount = (html: string): number => {
-  if (!html) return 0;
-  let text = html;
-  text = text.replace(
-    /<\/?(div|p|li|ul|ol|br|h[1-6]|table|tr|td|th|pre|blockquote)[^>]*>/gi,
-    ' '
-  );
-  text = text.replace(/<[^>]+>/g, '');
-  text = text.replace(/&nbsp;/g, ' ');
-  return text
-    .trim()
-    .split(/\s+/)
-    .filter((w) => w.length > 0).length;
-};
-
-/**
  * Inits the editor component.
  *
  * @param injector Parent instance angular injector containing all needed services and directives
@@ -78,7 +55,7 @@ export const init = (
         name: 'maxWords:number',
         category: 'general',
         default: -1,
-        visibleIndex: 2,
+        visibleIndex: -1,
       });
       return;
     },
@@ -142,22 +119,44 @@ export const init = (
           instance.editor.editor.writeValue(question.value);
         }
 
+        if (!question.wordLimitError) {
+          question.wordLimitError = new CustomError('', question);
+        }
+
+        if (question.maxWords && question.maxWords > 0) {
+          const wordCount = instance.getWordCount();
+          instance.wordCount = wordCount;
+
+          if (wordCount > question.maxWords) {
+            question.wordLimitError.text = `Maximum word limit is ${question.maxWords}. Current: ${wordCount}`;
+            if (!question.errors.includes(question.wordLimitError)) {
+              question.addError(question.wordLimitError);
+            }
+          } else {
+            question.removeError(question.wordLimitError);
+          }
+        } else {
+          question.removeError(question.wordLimitError);
+        }
+
         instance.html.subscribe((html) => {
           if (isNil(html)) {
             return;
           }
           if (question.maxWords && question.maxWords > 0) {
-            const wordCount = calculateWordCount(html);
+            const wordCount = instance.getWordCount();
+
             if (wordCount > question.maxWords) {
-              question.addError(
-                new CustomError(
-                  `Maximum word limit is ${question.maxWords}. Current: ${wordCount}`,
-                  question
-                )
-              );
+              question.wordLimitError.text = `Maximum word limit is ${question.maxWords}. Current: ${wordCount}`;
+
+              if (!question.errors.includes(question.wordLimitError)) {
+                question.addError(question.wordLimitError);
+              }
             } else {
-              question.clearErrors();
+              question.removeError(question.wordLimitError);
             }
+          } else {
+            question.removeError(question.wordLimitError);
           }
           if (question.survey?.isDesignMode) {
             question.defaultValue = html;

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -587,7 +587,7 @@ export const init = (
         getResourceById(question.resource).subscribe(({ data }) => {
           // const choices = mapQuestionChoices(data, question);
           // question.contentQuestion.choices = choices;
-          if (!question.placeholder) {
+          if (!question.placeholder && !question.displayAsGrid) {
             question.contentQuestion.optionsCaption =
               'Select a record from ' + data.resource.name + '...';
           }


### PR DESCRIPTION
# Description

This PR introduces a configurable word limit feature for the custom TinyMCE Editor question type in SurveyJS.

Key implementation details:

- Property Grid: Added a maxWords property to the Editor question settings (default: -1, meaning unlimited).
- Smart Counting Logic: Implemented a  word counting algorithm that correctly handles HTML structure:
  - Block tags (e.g., p, div, br) are treated as spaces to ensure separate paragraphs are counted as separate words.
  - Inline tags (e.g., b, span) are stripped to ensure formatted words (e.g., h<b>b</b>h) count as a single word.
  - HTML Entities (&nbsp) are normalized to spaces.
- Visual Feedback: Added a word counter below the editor that updates as the user types.
- Validation: Integrated with SurveyJS validation lifecycle to prevent form submission if the word count exceeds the limit.

## Useful links

Ticket: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=23fd463fd8c480c98edbd7f29ece23df&pm=s

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I have manually tested this component in the Form Builder, Preview mode, and Display mode.

Test Configuration (Form Builder):

- Added an "Editor" question to the form.
- Navigated to the "General" category in properties.
- Verified maxWords defaults to -1.
- Changed maxWords to 10.

Test Validation & UI (Preview Mode):

- Typed normal text. Verified counter shows "X / 10 words".
- Exceeded 10 words. Verified counter text turned red (e.g., "15 / 10 words (5 over limit)").
- Attempted to complete the survey. Verified that SurveyJS threw a validation error preventing submission.

Test HTML/Formatting Edge Cases:

- Block Tags: Typed "Hello" -> hit Enter -> typed "World". Verified this counts as 2 words (Block tags replaced with space).
- Inline Tags: Typed "hbh" (intercalated bold). Verified this counts as 1 word (Inline tags stripped completely).
- Spaces: Typed "Hello     World". Verified this counts as 2 words (Entities and multiple spaces collapsed).

## Screenshots

<img width="2206" height="443" alt="Screenshot from 2026-01-08 14-18-40" src="https://github.com/user-attachments/assets/4fb05da6-5225-4493-916d-6a16aee744ab" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
