### PR TITLE
Mab-419 shapefile errors

### DIFF
--- a/libs/shared/src/lib/components/shapefile-map/shapefile-map.component.ts
+++ b/libs/shared/src/lib/components/shapefile-map/shapefile-map.component.ts
@@ -25,7 +25,7 @@ export type ErrorType = {
 /** Error messages associated to errors */
 export const ERROR_MESSAGES: { [key in keyof ErrorType]: string } = {
   intersection:
-    'Geometry error: There are one or more self-intersecting polygons (polygons that cross themselves in a figure-eight fashion). Please correct these errors and upload the files again.',
+    'Geometry error: There are one or more overlapping zonation polygons. Please correct these errors and upload the files again.',
   gaps: 'Geometry error: There are one or more gaps (empty spaces) between zonation polygons. Please correct these errors and upload the files again.',
   overlap:
     'Geometry error: There are one or more overlapping zonation polygons. Please correct these errors and upload the files again.',

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -712,7 +712,7 @@ export class FormBuilderService {
           error: (error: HttpErrorResponse) => {
             this.snackBar.openSnackBar(error.message, {
               error: true,
-              duration: 15000,
+              duration: 25000,
             });
             options.callback(null, error);
           },


### PR DESCRIPTION
# Description

This PR updates the error messages and validation behavior for the Shapefile upload and map component to align with the requirements specified in the ticket. The changes ensure that geometry errors (gaps and overlaps) are clearly communicated to the user and that upload-related errors remain visible long enough to be read.

Changes:
- Merged Intersection & Overlap Messages: Updated ERROR_MESSAGES in ShapeFileMapComponent to use the same user-friendly message for both intersections and overlaps, as requested.
- Increased Snackbar Duration: Extended the display time for shapefile validation errors from 15 to 25 seconds in FormBuilderService to ensure users have enough time to read detailed error messages (like CRS requirements).
- Standardized Error Text: Ensured the "Gaps" error message matches the exact wording required by the ticket.

## Useful links

**Ticket:** https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=24cd463fd8c480218d7bcc037ba055f0&pm=s

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Test A: Geometry Errors (Map Level)
- Open a form with a ShapeFile question.
- Upload a .zip containing polygons with gaps.
    - Expected: Red alert on map shows: “Geometry error: There are one or more gaps (empty spaces) between zonation polygons. Please correct these errors and upload the files again.”
- Upload a .zip containing overlapping or intersecting polygons.
    - Expected: Red alert on map shows: “Geometry error: There are one or more overlapping zonation polygons. Please correct these errors and upload the files again.”

Test B: Upload Errors (Snackbar Level)
- Upload a .zip that triggers a backend validation error (e.g., wrong CRS or missing zonation).
- Expected: The snackbar popup appears with the error message and remains visible for 25 seconds (previously 15s).

## Screenshots

N/A

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
