### PR TITLE
MAB-624: Remove non visible questions from _progress

### DIFF
--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -78,21 +78,6 @@ export const transformSurveyData = (survey: SurveyModel) => {
     if (!question) {
       delete data[filed];
     } else {
-      const isQuestionVisible = (question: Question | IPanel): boolean => {
-        // If question is not visible, return false
-        if (!question.isVisible || !question) {
-          return false;
-        }
-
-        // If it is, check if its parent is visible
-        if (question.parent) {
-          return isQuestionVisible(question.parent);
-        }
-
-        // If we're in the root and it's visible, return true
-        return true;
-      };
-
       // Removes null values for invisible questions (or pages)
       if (
         (!isQuestionVisible(question) && data[filed] === null) ||
@@ -115,10 +100,12 @@ export const transformSurveyData = (survey: SurveyModel) => {
     }
   });
   if (survey.showPercentageProgressBar) {
-    // Filter only required questions that are not read-only and have input
+    // Filter only required questions that are not read-only, have input, and are visible (including parent visibility)
     const requiredQuestions = survey
       .getAllQuestions()
-      .filter((q) => q.isRequired && !q.readOnly && q.hasInput);
+      .filter(
+        (q) => q.isRequired && !q.readOnly && q.hasInput && isQuestionVisible(q)
+      );
 
     console.log(
       'Missing required questions: ',
@@ -136,6 +123,27 @@ export const transformSurveyData = (survey: SurveyModel) => {
     }
   }
   return data;
+};
+
+/**
+ * Checks if a question is visible, including parent visibility
+ *
+ * @param question Question or panel to check
+ * @returns True if the question and all its parents are visible
+ */
+export const isQuestionVisible = (question: Question | IPanel): boolean => {
+  // If question is not visible, return false
+  if (!question.isVisible || !question) {
+    return false;
+  }
+
+  // If it is, check if its parent is visible
+  if (question.parent) {
+    return isQuestionVisible(question.parent);
+  }
+
+  // If we're in the root and it's visible, return true
+  return true;
 };
 
 /**


### PR DESCRIPTION
# Description

Fixed the progress bar calculation on forms to exclude invisible questions from the percentage. 

The issue was that required questions hidden by isVisibleIf were still being counted. Created a isQuestionVisible() helper function that checks both the question and its parent visibility (it was already implemented locally), and we use it on the progress filter to update the value. 

Now, only visible required questions count for completion.

## Useful links

- https://www.notion.so/Remove-non-visible-questions-from-_progress-2edd463fd8c480e38c34ea3d4c707d6c?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules