### PR TITLE
MAB-627: Input too small in some fields

### DIFF
--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -120,9 +120,9 @@
       w-full
       border-0;
   }
-  .sd-text {
-    min-height: 2.5rem;
-  }
+  // .sd-text {
+  //   min-height: 2.5rem;
+  // }
   .k-multiselect {
     .k-clear-value {
       padding-right: 18px !important;
@@ -302,6 +302,13 @@
 
     .sv_row div {
       min-width: unset;
+    }
+  }
+
+  // Multi text
+  .sd-multipletext {
+    .sd-input {
+      min-height: 2.5rem;
     }
   }
 }

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -120,9 +120,7 @@
       w-full
       border-0;
   }
-  // .sd-text {
-  //   min-height: 2.5rem;
-  // }
+
   .k-multiselect {
     .k-clear-value {
       padding-right: 18px !important;

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -120,9 +120,9 @@
       w-full
       border-0;
   }
-  // .sd-text {
-  //   @apply text-sm h-10;
-  // }
+  .sd-text {
+    min-height: 2.5rem;
+  }
   .k-multiselect {
     .k-clear-value {
       padding-right: 18px !important;


### PR DESCRIPTION
# Description

The issue was that text input fields appeared too small in height, which looked off. It was fixed by adding min-height: 2.5rem (40px) to the .sd-text class in survey.scss, which specifically targets text and number inputs without affecting other form elements like dropdowns, checkboxes, or date pickers.

## Useful links

- https://www.notion.so/Input-too-small-in-some-fields-2edd463fd8c480e0a236d197febcdd67?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
