### PR TITLE
MAB-340: Text in non-html fields too small

### DIFF
--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -99,6 +99,7 @@
   .sd-input {
     padding: calc(1 * var(--sjs-base-unit, var(--base-unit, 8px)))
       calc(2 * var(--sjs-base-unit, var(--base-unit, 8px)));
+    font-size: 16px;
   }
   .k-combobox,
   .k-multiselect,
@@ -119,6 +120,15 @@
       items-center
       w-full
       border-0;
+  }
+  .k-combobox,
+  .k-multiselect,
+  .k-timepicker,
+  .k-datetimepicker,
+  .k-datepicker {
+    .k-input-inner {
+      font-size: 16px;
+    }
   }
   // .sd-text {
   //   @apply text-sm h-10;


### PR DESCRIPTION
# Description

Fixed the text in non-html fields being too small by setting a default font-size.

## Useful links

- https://www.notion.so/Text-in-non-html-fields-too-small-240d463fd8c480d5b397e79984290b80?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
