### PR TITLE
MAB-629: Duplicated JSON Editor in Dashboard Filter editor

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -268,7 +268,7 @@ export class FilterBuilderModalComponent
   private setFormBuilder() {
     const creatorOptions = {
       showEmbededSurveyTab: false,
-      showJSONEditorTab: true,
+      showJSONEditorTab: false,
       generateValidJSON: true,
       showTranslationTab: false,
       questionTypes: QUESTION_TYPES,


### PR DESCRIPTION
# Description

Fixed the duplicated JSON Editor in Dashboard Filter editor by setting showJSONEditorTab to false and only using the SurveyCustomJSONEditorPlugin.
 
## Useful links

- https://www.notion.so/Duplicated-JSON-Editor-in-Dashboard-Filter-editor-2edd463fd8c480829311c6c83e8e204f?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
