### PR TITLE
MAB-620 Link-to-site-profiles-on-country-details-page-broken

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -203,6 +203,11 @@ export class DashboardFilterComponent
     const oldFilterValues = this.contextService.filterValues.getValue();
     this.survey = this.contextService.initSurvey();
 
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.forEach((value, key) => {
+      this.survey.setVariable(`param.${key}`, value);
+    });
+
     if (this.dashboard?.filter?.keepPrevious) {
       Object.keys(oldFilterValues ?? {}).forEach((key) => {
         const question = this.survey.getQuestionByName(key);

--- a/libs/shared/src/lib/survey/components/resource.ts
+++ b/libs/shared/src/lib/survey/components/resource.ts
@@ -157,6 +157,27 @@ export const init = (
       }
     }
 
+    if (record && question.contentQuestion) {
+      const currentChoices = question.contentQuestion.choices || [];
+      const choiceIndex = currentChoices.findIndex(
+        (c: any) => c.value === recordID
+      );
+      const realName = record.data[question.displayField || 'id'] || recordID;
+
+      if (choiceIndex === -1) {
+        question.contentQuestion.choices = [
+          ...currentChoices,
+          { value: recordID, text: realName },
+        ];
+      } else {
+        if (currentChoices[choiceIndex].text !== realName) {
+          const newChoices = [...currentChoices];
+          newChoices[choiceIndex] = { value: recordID, text: realName };
+          question.contentQuestion.choices = newChoices;
+        }
+      }
+    }
+
     const data = record?.data || {};
 
     // Creates strStruct once if doesn't exist
@@ -165,9 +186,50 @@ export const init = (
     }
 
     for (const field in data) {
-      const varUsed = new RegExp(`{\\s*${question.name}\\.${field}\\s*}`);
-      if (varUsed.test(survey.strStructure)) {
-        survey.setVariable(`${question.name}.${field}`, data[field]);
+      const value = data[field];
+
+      // Set the exact variable (e.g. selected_br.a_06_country)
+      survey.setVariable(`${question.name}.${field}`, value);
+
+      // ALIAS: If it ends in _country, also set it as .country
+      // This allows {selected_br.country} to work even if DB sends a_06_country
+      if (field.endsWith('_country')) {
+        survey.setVariable(`${question.name}.country`, value);
+      }
+    }
+
+    if (question.name === 'selected_br') {
+      const countryQuestion = survey.getQuestionByName('selected_country');
+      if (countryQuestion) {
+        const dataObj = data as { [key: string]: unknown };
+        const directCountryKey = Object.keys(dataObj).find(
+          (key) => key === 'country'
+        );
+        const suffixCountryKey = Object.keys(dataObj).find((key) =>
+          key.endsWith('_country')
+        );
+        const countryKey = directCountryKey || suffixCountryKey;
+        const recordCountry = countryKey ? dataObj[countryKey] : null;
+
+        const surveyAny = survey as SurveyModel & {
+          __selectedCountryAuto?: boolean;
+          __selectedCountryManual?: boolean;
+        };
+
+        const shouldSyncCountry =
+          !surveyAny.__selectedCountryManual ||
+          isNil(countryQuestion.value) ||
+          countryQuestion.value === '';
+
+        if (
+          !isNil(recordCountry) &&
+          recordCountry !== '' &&
+          shouldSyncCountry
+        ) {
+          surveyAny.__selectedCountryAuto = true;
+          countryQuestion.value = recordCountry;
+          surveyAny.__selectedCountryAuto = false;
+        }
       }
     }
   };
@@ -194,7 +256,20 @@ export const init = (
     });
 
   const populateChoices = (question: QuestionResource): void => {
-    const filters = getUpdatedFilter(question);
+    const survey = question.survey as SurveyModel;
+    const surveyAny = survey as SurveyModel & {
+      __selectedCountryManual?: boolean;
+    };
+    const reserveId = survey?.getVariable?.('param.reserve_id');
+    const ignoreReserveId = surveyAny.__selectedCountryManual === true;
+    const effectiveReserveId = ignoreReserveId ? null : reserveId;
+    const filters = effectiveReserveId
+      ? ({
+          logic: 'and',
+          filters: [] as FilterDescriptor[],
+        } satisfies CompositeFilterDescriptor)
+      : getUpdatedFilter(question);
+
     if (
       question.resource &&
       !(question.customFilter && Array.isArray(filters) && filters.length === 0)
@@ -202,23 +277,138 @@ export const init = (
       getResourceRecordsById({ id: question.resource, filters }).subscribe(
         ({ data }) => {
           const choices = mapQuestionChoices(data, question);
+
+          if (question.autoSelectFirstOption || question.autoSelectOnlyOption) {
+            if (question.value && choices.length > 0) {
+              const isValid = choices.some(
+                (c: any) => c.value === question.value
+              );
+              if (!isValid) {
+                question.value = null;
+              }
+            }
+          }
+
+          const shouldIgnoreEffectiveValue =
+            question.name === 'selected_br' &&
+            surveyAny.__selectedCountryManual;
+          const effectiveValue = shouldIgnoreEffectiveValue
+            ? null
+            : question.value || question.defaultValue;
+
+          if (effectiveValue) {
+            const inNewList = choices.some(
+              (c: any) => c.value === effectiveValue
+            );
+
+            // Only preserve missing values if we are NOT in auto-select mode
+            if (
+              !inNewList &&
+              !question.autoSelectFirstOption &&
+              !question.autoSelectOnlyOption
+            ) {
+              const currentChoices = question.contentQuestion.choices || [];
+              const preservedChoice = currentChoices.find(
+                (c: any) => c.value === effectiveValue
+              );
+
+              if (preservedChoice) {
+                choices.push(preservedChoice);
+              } else {
+                choices.push({ value: effectiveValue, text: effectiveValue });
+              }
+            }
+          }
+
           question.contentQuestion.choices = choices;
 
-          // Auto select the first option if the option is set, only applicable if question doesn't have a value yet
           if (
             (question.autoSelectFirstOption && choices.length > 0) ||
             (question.autoSelectOnlyOption && choices.length === 1)
           ) {
-            setTimeout(() => {
-              question.value = question.value ?? choices[0].value;
-            }, 500);
-          }
+            const tryApplyValue = (val: string | null) => {
+              if (!val) return false;
+              const exists = choices.some((c: any) => c.value === val);
+              if (exists) {
+                question.value = val;
+                return true;
+              }
+              return false;
+            };
 
+            const resolveDefaultValue = () => {
+              const urlParams = new URLSearchParams(window.location.search);
+              const urlValue = urlParams.get(question.name);
+
+              if (tryApplyValue(urlValue)) return true;
+
+              const paramValue = survey?.getVariable?.(
+                `param.${question.name}`
+              );
+              if (tryApplyValue(paramValue)) return true;
+
+              if (question.defaultValueExpression) {
+                let expressionValue = survey.runExpression(
+                  question.defaultValueExpression
+                );
+                if (
+                  !expressionValue &&
+                  !question.defaultValueExpression.includes('||')
+                ) {
+                  const rawVar = question.defaultValueExpression
+                    .trim()
+                    .replace(/^\{|\}$/g, '');
+                  expressionValue = survey.getVariable(rawVar);
+                }
+                if (tryApplyValue(expressionValue)) return true;
+              }
+
+              if (question.defaultValue) {
+                if (tryApplyValue(question.defaultValue)) return true;
+              }
+
+              if (question.value) {
+                const isValid = choices.some(
+                  (c: any) => c.value === question.value
+                );
+                if (isValid) return true;
+              }
+
+              return false;
+            };
+
+            setTimeout(() => {
+              const resolved = resolveDefaultValue();
+              if (effectiveReserveId) {
+                return;
+              }
+              // If we couldn't find a valid value from params/url/expression,
+              // AND we have choices available, pick the first one.
+              if (!resolved && choices.length > 0) {
+                question.value = choices[0].value;
+              }
+            }, 5000);
+
+            const recheck = (_: any, options: any) => {
+              if (
+                options.name === question.name ||
+                options.name === `param.${question.name}`
+              ) {
+                return;
+              }
+              const resolved = resolveDefaultValue();
+              if (resolved) {
+                survey.onValueChanged.remove(recheck);
+              }
+            };
+
+            survey.onValueChanged.add(recheck);
+          }
           if (!question.placeholder) {
             question.contentQuestion.optionsCaption =
               'Select a record from ' + data.resource.name + '...';
           }
-          addRecordToSurveyContext(question, question.value);
+          addRecordToSurveyContext(question, question.value || effectiveValue);
         }
       );
     } else {
@@ -761,8 +951,43 @@ export const init = (
     // Display of add button for resource question ans set placeholder, if any
     onAfterRender: (question: QuestionResource, el: HTMLElement): void => {
       const survey: SurveyModel = question.survey as SurveyModel;
+      const surveyAny = survey as SurveyModel & {
+        __selectedCountrySyncInit?: boolean;
+        __selectedCountryAuto?: boolean;
+        __selectedCountryManual?: boolean;
+      };
       loadedRecords.clear();
       survey.loadedRecords = loadedRecords;
+
+      if (!surveyAny.__selectedCountrySyncInit) {
+        const countryQuestion = survey.getQuestionByName('selected_country');
+        if (countryQuestion) {
+          countryQuestion.registerFunctionOnPropertyValueChanged(
+            'value',
+            (value: unknown) => {
+              if (surveyAny.__selectedCountryAuto) {
+                return;
+              }
+              const hasValue = !isNil(value) && value !== '';
+              surveyAny.__selectedCountryManual = hasValue;
+              if (!hasValue) {
+                surveyAny.__selectedCountryManual = false;
+                return;
+              }
+
+              const brQuestion = survey.getQuestionByName('selected_br');
+              if (brQuestion) {
+                brQuestion.value = null;
+              }
+            }
+          );
+          surveyAny.__selectedCountrySyncInit = true;
+        }
+      }
+
+      if (question.value) {
+        addRecordToSurveyContext(question, question.value);
+      }
 
       // If using custom filters, we need to update the filters and populate the choices
       // note: we do this here instead of onLoaded because we need the survey initial values


### PR DESCRIPTION

# Description

This PR fixes an issue where clicking on a Site Profile link from the Country Details page resulted in a blank page or loaded an incorrect default location.

The issue was caused by a race condition in the resource question component where the autoSelectFirstOption logic would trigger before the dashboard variables (like param.reserve_id) were fully loaded. Additionally, "sticky" values were persisting when switching between countries, causing invalid sites to remain selected.

**Key changes in resource.ts:**
- Added Validation Logic: Implemented tryApplyValue to ensure that any selected value (from URL, variables, or defaults) actually exists in the current filtered list. If a value is invalid for the current context (e.g., an old Site not belonging to the new Country), it is rejected.
- Improved Async Handling: Updated populateChoices to wait for SurveyJS variables or complex defaultValueExpressions to resolve before falling back to the "First Option".
- Complex Expression Support: Added support for survey.runExpression() to correctly parse chains.
- Map Synchronization: Ensured addRecordToSurveyContext is called with valid data to fix the synchronization between the Map widget and the dropdowns.

## Useful links

- **Ticket:** https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2e9d463fd8c480b8a45df1ad1a2c6869&pm=s

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- **Direct Link Navigation:** Navigated from the Country Details page to a specific Site Profile (URL containing reserve_id). Verified that the correct Site loaded immediately instead of a blank page or the default first option.
- **Cascading Validation:** Selected a Country (e.g., Argentina) and a specific Site. Then changed the Country to a different one. Verified that the Site dropdown correctly cleared the invalid br site and auto-selected the first valid site for the new Country.
- **Map Interaction:** Verified that clicking a Site correctly updates the dropdown logic and fills the dependent Country field via the complex defaultValueExpression.

## Screenshots

N/A

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
