### PR TITLE
MAB-646: The user’s location in the form should not change when they click save

### DIFF
--- a/libs/shared/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.html
@@ -105,7 +105,7 @@
           category="secondary"
           variant="primary"
           [disabled]="saving || submitting || autosaving"
-          (click)="survey.completeLastPage()"
+          (click)="onSave()"
           cdkFocusInitial
         >
           <span class="flex items-center whitespace-nowrap">
@@ -142,7 +142,7 @@
         category="secondary"
         variant="primary"
         [disabled]="saving || autosaving"
-        (click)="submit()"
+        (click)="onSave()"
         cdkFocusInitial
       >
         <ng-container *ngIf="!autosaving">

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -192,6 +192,8 @@ export class FormModalComponent
   private autoSaveInterval?: Subscription;
   /** Stringified version of last saved survey data for autosave comparison */
   private lastSavedDataState?: string;
+  /** Last page index captured for manual save */
+  private manualSavePageIndex?: number;
 
   /**
    * Modal to edit or add a record.
@@ -623,6 +625,39 @@ export class FormModalComponent
   }
 
   /**
+   * Capture current page before saving to preserve location.
+   */
+  public onSave(): void {
+    this.captureManualSavePageIndex();
+
+    if (this.survey?.enableSaveAndSubmit) {
+      this.survey.completeLastPage();
+    } else {
+      this.submit();
+    }
+  }
+
+  private captureManualSavePageIndex(): void {
+    this.manualSavePageIndex = this.selectedPageIndex.getValue();
+  }
+
+  private restoreManualSavePageIndex(): void {
+    if (this.manualSavePageIndex === undefined) {
+      return;
+    }
+
+    this.survey.showCompletedPage = false;
+    const maxIndex = Math.max(this.survey.visiblePages.length - 1, 0);
+    const nextIndex = Math.min(this.manualSavePageIndex, maxIndex);
+
+    if (this.selectedPageIndex.getValue() !== nextIndex) {
+      this.selectedPageIndex.next(nextIndex);
+    }
+
+    this.manualSavePageIndex = undefined;
+  }
+
+  /**
    * Closes the dialog asking for confirmation if needed.
    */
   public close(): void {
@@ -695,6 +730,7 @@ export class FormModalComponent
           } else {
             this.saving = false;
             this.submitting = false;
+            this.restoreManualSavePageIndex();
           }
         });
       // Updates the data directly.
@@ -788,10 +824,12 @@ export class FormModalComponent
                       }
                     });
                     this.data.recordId = data?.addRecord.id;
+                    this.restoreManualSavePageIndex();
                   }
                 },
                 error: (err) => {
                   this.snackBar.openSnackBar(err.message, { error: true });
+                  this.restoreManualSavePageIndex();
                 },
               });
           }
@@ -803,7 +841,20 @@ export class FormModalComponent
           this.survey.clear(false);
           this.autosaving = false;
           this.saving = false;
+          this.restoreManualSavePageIndex();
         }
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error
+            ? error.message
+            : this.translate.instant('models.form.notifications.savingFailed');
+        this.snackBar.openSnackBar(message, { error: true });
+        this.loading = false;
+        this.autosaving = false;
+        this.saving = false;
+        this.submitting = false;
+        this.restoreManualSavePageIndex();
       });
   }
 
@@ -845,6 +896,7 @@ export class FormModalComponent
           this.submitting = false;
           this.latestSaveDate = new Date();
           this.lastSavedDataState = JSON.stringify(this.survey.data ?? {});
+          this.restoreManualSavePageIndex();
         },
         error: (err) => {
           this.snackBar.openSnackBar(err.message, { error: true });
@@ -852,6 +904,7 @@ export class FormModalComponent
           this.autosaving = false;
           this.saving = false;
           this.submitting = false;
+          this.restoreManualSavePageIndex();
         },
       });
   }
@@ -901,6 +954,7 @@ export class FormModalComponent
           this.loading = false;
           this.autosaving = false;
           this.saving = false;
+          this.restoreManualSavePageIndex();
         },
         error: (err) => {
           this.snackBar.openSnackBar(err.message, { error: true });
@@ -908,6 +962,7 @@ export class FormModalComponent
           this.autosaving = false;
           this.saving = false;
           this.submitting = false;
+          this.restoreManualSavePageIndex();
         },
       });
   }

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -637,10 +637,16 @@ export class FormModalComponent
     }
   }
 
+  /**
+   * Captures the current page index for manual save restoration
+   */
   private captureManualSavePageIndex(): void {
     this.manualSavePageIndex = this.selectedPageIndex.getValue();
   }
 
+  /**
+   * Restores the page index after manual save
+   */
   private restoreManualSavePageIndex(): void {
     if (this.manualSavePageIndex === undefined) {
       return;

--- a/libs/shared/src/lib/components/form/form.component.html
+++ b/libs/shared/src/lib/components/form/form.component.html
@@ -125,7 +125,7 @@
           variant="primary"
           category="secondary"
           [disabled]="saving || submitting || autosaving"
-          (click)="survey.completeLastPage()"
+          (click)="onSave()"
         >
           <span class="flex items-center whitespace-nowrap">
             {{ 'common.save' | translate }}
@@ -161,7 +161,7 @@
           variant="primary"
           category="secondary"
           [disabled]="autosaving"
-          (click)="submit()"
+          (click)="onSave()"
         >
           <ng-container *ngIf="!autosaving">
             {{ saveButtonText }}

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -331,13 +331,33 @@ export class FormComponent
    * Capture current page before saving to preserve location.
    */
   public onSave(): void {
-    this.manualSavePageIndex = this.selectedPageIndex.getValue();
+    this.captureManualSavePageIndex();
 
     if (this.survey?.enableSaveAndSubmit) {
       this.survey.completeLastPage();
     } else {
       this.submit();
     }
+  }
+
+  private captureManualSavePageIndex(): void {
+    this.manualSavePageIndex = this.selectedPageIndex.getValue();
+  }
+
+  private restoreManualSavePageIndex(): void {
+    if (this.manualSavePageIndex === undefined) {
+      return;
+    }
+
+    this.survey.showCompletedPage = false;
+    const maxIndex = Math.max(this.survey.visiblePages.length - 1, 0);
+    const nextIndex = Math.min(this.manualSavePageIndex, maxIndex);
+
+    if (this.selectedPageIndex.getValue() !== nextIndex) {
+      this.selectedPageIndex.next(nextIndex);
+    }
+
+    this.manualSavePageIndex = undefined;
   }
 
   /**
@@ -371,23 +391,6 @@ export class FormComponent
    * @param autoSave whether the save is automatic or manual
    */
   private async onComplete(autoSave = false) {
-    const previousPageIndex =
-      this.manualSavePageIndex ?? this.selectedPageIndex.getValue();
-    const restorePageIndex = () => {
-      if (this.survey.showCompletedPage) {
-        this.manualSavePageIndex = undefined;
-        return;
-      }
-
-      const maxIndex = Math.max(this.survey.visiblePages.length - 1, 0);
-      const nextIndex = Math.min(previousPageIndex, maxIndex);
-
-      if (this.selectedPageIndex.getValue() !== nextIndex) {
-        this.selectedPageIndex.next(nextIndex);
-      }
-      this.manualSavePageIndex = undefined;
-    };
-
     this.formHelpersService
       .checkUniquePropriety(this.survey)
       .then(async (response: CheckUniqueProprietyReturnT) => {
@@ -507,7 +510,7 @@ export class FormComponent
                 this.lastSavedDataState = JSON.stringify(
                   this.survey.data ?? {}
                 );
-                restorePageIndex();
+                this.restoreManualSavePageIndex();
               },
               error: (error: unknown) => {
                 const message =
@@ -521,7 +524,7 @@ export class FormComponent
                 this.autosaving = false;
                 this.submitting = false;
                 this.surveyActive = true;
-                restorePageIndex();
+                this.restoreManualSavePageIndex();
               },
             });
         } else {
@@ -529,7 +532,7 @@ export class FormComponent
             this.translate.instant('components.form.display.cancelMessage')
           );
           this.survey.clear(false);
-          restorePageIndex();
+          this.restoreManualSavePageIndex();
         }
       })
       .catch((error: unknown) => {
@@ -542,7 +545,7 @@ export class FormComponent
         this.autosaving = false;
         this.submitting = false;
         this.surveyActive = true;
-        restorePageIndex();
+        this.restoreManualSavePageIndex();
       });
   }
 

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -156,6 +156,8 @@ export class FormComponent
   private autoSaveInterval?: Subscription;
   /** Stringified version of last saved survey data for autosave comparison */
   private lastSavedDataState?: string;
+  /** Last page index captured for manual save */
+  private manualSavePageIndex?: number;
 
   /**
    * Gets the error questions for current page
@@ -326,6 +328,19 @@ export class FormComponent
   }
 
   /**
+   * Capture current page before saving to preserve location.
+   */
+  public onSave(): void {
+    this.manualSavePageIndex = this.selectedPageIndex.getValue();
+
+    if (this.survey?.enableSaveAndSubmit) {
+      this.survey.completeLastPage();
+    } else {
+      this.submit();
+    }
+  }
+
+  /**
    * Saves the current data as a draft record
    */
   public saveAsDraft(): void {
@@ -356,6 +371,23 @@ export class FormComponent
    * @param autoSave whether the save is automatic or manual
    */
   private async onComplete(autoSave = false) {
+    const previousPageIndex =
+      this.manualSavePageIndex ?? this.selectedPageIndex.getValue();
+    const restorePageIndex = () => {
+      if (this.survey.showCompletedPage) {
+        this.manualSavePageIndex = undefined;
+        return;
+      }
+
+      const maxIndex = Math.max(this.survey.visiblePages.length - 1, 0);
+      const nextIndex = Math.min(previousPageIndex, maxIndex);
+
+      if (this.selectedPageIndex.getValue() !== nextIndex) {
+        this.selectedPageIndex.next(nextIndex);
+      }
+      this.manualSavePageIndex = undefined;
+    };
+
     this.formHelpersService
       .checkUniquePropriety(this.survey)
       .then(async (response: CheckUniqueProprietyReturnT) => {
@@ -413,72 +445,104 @@ export class FormComponent
           }
           mutation
             .pipe(takeUntil(this.destroy$))
-            .subscribe(({ errors, data }: any) => {
-              if (errors) {
-                this.save.emit({ completed: false });
-                this.survey.clear(false, true);
-                this.surveyActive = true;
-                this.snackBar.openSnackBar(errors[0].message, {
-                  error: true,
-                });
-              } else {
-                if (this.lastDraftRecord) {
-                  const callback = () => {
-                    this.lastDraftRecord = undefined;
-                  };
-                  this.formHelpersService.deleteRecordDraft(
-                    this.lastDraftRecord,
-                    callback
-                  );
-                }
-
-                const shouldClearSurvey =
-                  !this.submitting &&
-                  !this.survey.alwaysShowCompletedPage &&
-                  (data.editRecord ||
-                    data.addRecord?.form.uniqueRecord ||
-                    autoSave);
-
-                if (shouldClearSurvey) {
-                  this.survey.clear(false, false);
-                  if (data.addRecord) {
-                    this.record = data.addRecord;
-                    this.modifiedAt = this.record?.modifiedAt || null;
-                  } else {
-                    this.modifiedAt = data.editRecord?.modifiedAt;
-                  }
+            .subscribe({
+              next: ({ errors, data }: any) => {
+                if (errors) {
+                  this.save.emit({ completed: false });
+                  this.survey.clear(false, true);
                   this.surveyActive = true;
-                } else if (this.submitting) {
-                  if (data.addRecord) {
-                    this.record = data.addRecord;
-                    this.modifiedAt = this.record?.modifiedAt || null;
-                  } else if (data.editRecord) {
-                    this.modifiedAt = data.editRecord.modifiedAt;
-                  }
-                  this.survey.showCompletedPage = true; // Show completion message after Save & Submit
-                  this.surveyActive = true;
+                  this.snackBar.openSnackBar(errors[0].message, {
+                    error: true,
+                  });
                 } else {
-                  this.survey.showCompletedPage = true;
+                  if (this.lastDraftRecord) {
+                    const callback = () => {
+                      this.lastDraftRecord = undefined;
+                    };
+                    this.formHelpersService.deleteRecordDraft(
+                      this.lastDraftRecord,
+                      callback
+                    );
+                  }
+
+                  const shouldClearSurvey =
+                    !this.submitting &&
+                    !this.survey.alwaysShowCompletedPage &&
+                    (data.editRecord ||
+                      data.addRecord?.form.uniqueRecord ||
+                      autoSave);
+
+                  if (shouldClearSurvey) {
+                    this.survey.clear(false, false);
+                    if (data.addRecord) {
+                      this.record = data.addRecord;
+                      this.modifiedAt = this.record?.modifiedAt || null;
+                    } else {
+                      this.modifiedAt = data.editRecord?.modifiedAt;
+                    }
+                    this.surveyActive = true;
+                  } else if (this.submitting) {
+                    if (data.addRecord) {
+                      this.record = data.addRecord;
+                      this.modifiedAt = this.record?.modifiedAt || null;
+                    } else if (data.editRecord) {
+                      this.modifiedAt = data.editRecord.modifiedAt;
+                    }
+                    this.survey.showCompletedPage = true; // Show completion message after Save & Submit
+                    this.surveyActive = true;
+                  } else {
+                    this.survey.showCompletedPage = true;
+                  }
+
+                  this.save.emit({
+                    completed: true,
+                    hideNewRecord: true, // Always hide new record button after submission
+                  });
                 }
 
-                this.save.emit({
-                  completed: true,
-                  hideNewRecord: true, // Always hide new record button after submission
-                });
-              }
-
-              this.saving = false;
-              this.autosaving = false;
-              this.submitting = false;
-              this.latestSaveDate = new Date();
-              this.lastSavedDataState = JSON.stringify(this.survey.data ?? {});
+                this.saving = false;
+                this.autosaving = false;
+                this.submitting = false;
+                this.latestSaveDate = new Date();
+                this.lastSavedDataState = JSON.stringify(
+                  this.survey.data ?? {}
+                );
+                restorePageIndex();
+              },
+              error: (error: unknown) => {
+                const message =
+                  error instanceof Error
+                    ? error.message
+                    : this.translate.instant(
+                        'models.form.notifications.savingFailed'
+                      );
+                this.snackBar.openSnackBar(message, { error: true });
+                this.saving = false;
+                this.autosaving = false;
+                this.submitting = false;
+                this.surveyActive = true;
+                restorePageIndex();
+              },
             });
         } else {
           this.snackBar.openSnackBar(
             this.translate.instant('components.form.display.cancelMessage')
           );
           this.survey.clear(false);
+          restorePageIndex();
         }
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error
+            ? error.message
+            : this.translate.instant('models.form.notifications.savingFailed');
+        this.snackBar.openSnackBar(message, { error: true });
+        this.saving = false;
+        this.autosaving = false;
+        this.submitting = false;
+        this.surveyActive = true;
+        restorePageIndex();
       });
   }
 

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -340,10 +340,16 @@ export class FormComponent
     }
   }
 
+  /**
+   * Captures the current page index for manual save restoration
+   */
   private captureManualSavePageIndex(): void {
     this.manualSavePageIndex = this.selectedPageIndex.getValue();
   }
 
+  /**
+   * Restores the page index after manual save
+   */
   private restoreManualSavePageIndex(): void {
     if (this.manualSavePageIndex === undefined) {
       return;
@@ -446,87 +452,83 @@ export class FormComponent
               },
             });
           }
-          mutation
-            .pipe(takeUntil(this.destroy$))
-            .subscribe({
-              next: ({ errors, data }: any) => {
-                if (errors) {
-                  this.save.emit({ completed: false });
-                  this.survey.clear(false, true);
-                  this.surveyActive = true;
-                  this.snackBar.openSnackBar(errors[0].message, {
-                    error: true,
-                  });
-                } else {
-                  if (this.lastDraftRecord) {
-                    const callback = () => {
-                      this.lastDraftRecord = undefined;
-                    };
-                    this.formHelpersService.deleteRecordDraft(
-                      this.lastDraftRecord,
-                      callback
-                    );
-                  }
-
-                  const shouldClearSurvey =
-                    !this.submitting &&
-                    !this.survey.alwaysShowCompletedPage &&
-                    (data.editRecord ||
-                      data.addRecord?.form.uniqueRecord ||
-                      autoSave);
-
-                  if (shouldClearSurvey) {
-                    this.survey.clear(false, false);
-                    if (data.addRecord) {
-                      this.record = data.addRecord;
-                      this.modifiedAt = this.record?.modifiedAt || null;
-                    } else {
-                      this.modifiedAt = data.editRecord?.modifiedAt;
-                    }
-                    this.surveyActive = true;
-                  } else if (this.submitting) {
-                    if (data.addRecord) {
-                      this.record = data.addRecord;
-                      this.modifiedAt = this.record?.modifiedAt || null;
-                    } else if (data.editRecord) {
-                      this.modifiedAt = data.editRecord.modifiedAt;
-                    }
-                    this.survey.showCompletedPage = true; // Show completion message after Save & Submit
-                    this.surveyActive = true;
-                  } else {
-                    this.survey.showCompletedPage = true;
-                  }
-
-                  this.save.emit({
-                    completed: true,
-                    hideNewRecord: true, // Always hide new record button after submission
-                  });
+          mutation.pipe(takeUntil(this.destroy$)).subscribe({
+            next: ({ errors, data }: any) => {
+              if (errors) {
+                this.save.emit({ completed: false });
+                this.survey.clear(false, true);
+                this.surveyActive = true;
+                this.snackBar.openSnackBar(errors[0].message, {
+                  error: true,
+                });
+              } else {
+                if (this.lastDraftRecord) {
+                  const callback = () => {
+                    this.lastDraftRecord = undefined;
+                  };
+                  this.formHelpersService.deleteRecordDraft(
+                    this.lastDraftRecord,
+                    callback
+                  );
                 }
 
-                this.saving = false;
-                this.autosaving = false;
-                this.submitting = false;
-                this.latestSaveDate = new Date();
-                this.lastSavedDataState = JSON.stringify(
-                  this.survey.data ?? {}
-                );
-                this.restoreManualSavePageIndex();
-              },
-              error: (error: unknown) => {
-                const message =
-                  error instanceof Error
-                    ? error.message
-                    : this.translate.instant(
-                        'models.form.notifications.savingFailed'
-                      );
-                this.snackBar.openSnackBar(message, { error: true });
-                this.saving = false;
-                this.autosaving = false;
-                this.submitting = false;
-                this.surveyActive = true;
-                this.restoreManualSavePageIndex();
-              },
-            });
+                const shouldClearSurvey =
+                  !this.submitting &&
+                  !this.survey.alwaysShowCompletedPage &&
+                  (data.editRecord ||
+                    data.addRecord?.form.uniqueRecord ||
+                    autoSave);
+
+                if (shouldClearSurvey) {
+                  this.survey.clear(false, false);
+                  if (data.addRecord) {
+                    this.record = data.addRecord;
+                    this.modifiedAt = this.record?.modifiedAt || null;
+                  } else {
+                    this.modifiedAt = data.editRecord?.modifiedAt;
+                  }
+                  this.surveyActive = true;
+                } else if (this.submitting) {
+                  if (data.addRecord) {
+                    this.record = data.addRecord;
+                    this.modifiedAt = this.record?.modifiedAt || null;
+                  } else if (data.editRecord) {
+                    this.modifiedAt = data.editRecord.modifiedAt;
+                  }
+                  this.survey.showCompletedPage = true; // Show completion message after Save & Submit
+                  this.surveyActive = true;
+                } else {
+                  this.survey.showCompletedPage = true;
+                }
+
+                this.save.emit({
+                  completed: true,
+                  hideNewRecord: true, // Always hide new record button after submission
+                });
+              }
+
+              this.saving = false;
+              this.autosaving = false;
+              this.submitting = false;
+              this.latestSaveDate = new Date();
+              this.lastSavedDataState = JSON.stringify(this.survey.data ?? {});
+              this.restoreManualSavePageIndex();
+            },
+            error: (error: unknown) => {
+              const message =
+                error instanceof Error
+                  ? error.message
+                  : this.translate.instant(
+                      'models.form.notifications.savingFailed'
+                    );
+              this.snackBar.openSnackBar(message, { error: true });
+              this.saving = false;
+              this.autosaving = false;
+              this.submitting = false;
+              this.surveyActive = true;
+              this.restoreManualSavePageIndex();
+            },
+          });
         } else {
           this.snackBar.openSnackBar(
             this.translate.instant('components.form.display.cancelMessage')


### PR DESCRIPTION
# Description

The issue was that the save flow triggered survey.completeLastPage() (or a submit() that calls it), which makes SurveyJS jump to the last page and re‑render the survey, resetting currentPageNo back to the first page, and since we never captured and restored the user’s current page index, any manual save caused the UI to land on page 1. It is now fixed by capturing the current page index when the user clicks save and restoring it after the save finishes.

## Useful links

- https://www.notion.so/The-user-s-location-in-the-form-should-not-change-when-they-click-save-2f1d463fd8c480eb8268fcbb53de7fc3?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
