### PR TITLE
MAB-662 -Implement automatic widget refresh after form save

### DIFF
--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -263,6 +263,13 @@ export class AggregationGridComponent
   }
 
   /**
+   * Reload the aggregation data
+   */
+  public reloadData(): void {
+    this.getAggregationData();
+  }
+
+  /**
    * Detects sort events and update the items loaded.
    *
    * @param sort Sort event.

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -83,6 +83,7 @@ import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { FormPagesLayoutComponent } from '../form-pages-layout/form-pages-layout.component';
 import { DateModule } from '../../pipes/date/date.module';
+import { RefreshService } from '../../services/refresh/refresh.service';
 
 /** Question type which should not display the add comment button when hovered */
 const UNCOMMENTABLE_TYPES = ['html'];
@@ -210,6 +211,7 @@ export class FormModalComponent
    * @param contextService Shared context service
    * @param overlay cdk overlay
    * @param viewContainerRef View container ref
+   * @param refreshService This is the service that allows triggering a data refresh
    */
   constructor(
     @Inject(DIALOG_DATA) public data: DialogData,
@@ -225,7 +227,8 @@ export class FormModalComponent
     protected ngZone: NgZone,
     protected contextService: ContextService,
     private overlay: Overlay,
-    private viewContainerRef: ViewContainerRef
+    private viewContainerRef: ViewContainerRef,
+    private refreshService: RefreshService
   ) {
     super();
   }
@@ -795,6 +798,11 @@ export class FormModalComponent
                       }
                     });
                     this.data.recordId = data?.addRecord.id;
+                    this.refreshService.triggerRecordCreated(
+                      this.form?.id,
+                      data?.addRecord.id,
+                      this.form?.resource?.id
+                    );
                   }
                 },
                 error: (err) => {
@@ -853,6 +861,11 @@ export class FormModalComponent
           this.submitting = false;
           this.latestSaveDate = new Date();
           this.lastSavedDataState = JSON.stringify(this.survey.data ?? {});
+          this.refreshService.triggerRecordUpdate(
+            this.form?.id,
+            id,
+            this.form?.resource?.id
+          );
         },
         error: (err) => {
           this.snackBar.openSnackBar(err.message, { error: true });
@@ -911,6 +924,11 @@ export class FormModalComponent
           this.autosaving = false;
           this.saving = false;
           this.survey.readOnly = false;
+          this.refreshService.triggerRecordUpdate(
+            this.form?.id,
+            ids,
+            this.form?.resource?.id
+          );
         },
         error: (err) => {
           this.snackBar.openSnackBar(err.message, { error: true });

--- a/libs/shared/src/lib/components/ui/reference-data-grid/reference-data-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/reference-data-grid/reference-data-grid.component.ts
@@ -69,6 +69,16 @@ export class ReferenceDataGridComponent implements OnInit {
   }
 
   /**
+   * Reload the grid data
+   */
+  public reloadData(): void {
+    if (this.settings && this.settings.refDataCards) {
+      this.cards = this.settings.refDataCards;
+      this.setGridData();
+    }
+  }
+
+  /**
    * Get meta type for grid based on json type
    *
    * @param type json type

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -53,6 +53,7 @@ import { AggregationGridComponent } from '../../aggregation/aggregation-grid/agg
 import { ReferenceDataGridComponent } from '../../ui/reference-data-grid/reference-data-grid.component';
 import { DashboardService } from '../../../services/dashboard/dashboard.service';
 import { Router } from '@angular/router';
+import { RefreshService } from '../../../services/refresh/refresh.service';
 
 /** Component for the grid widget */
 @Component({
@@ -163,6 +164,7 @@ export class GridWidgetComponent
    * @param aggregationService Shared aggregation service
    * @param dashboardService Shared dashboard service
    * @param router Angular router
+   * @param refreshService
    */
   constructor(
     @Inject('environment') environment: any,
@@ -178,7 +180,8 @@ export class GridWidgetComponent
     private translate: TranslateService,
     private aggregationService: AggregationService,
     private dashboardService: DashboardService,
-    private router: Router
+    private router: Router,
+    private refreshService: RefreshService
   ) {
     super();
     this.environment = environment;
@@ -187,6 +190,30 @@ export class GridWidgetComponent
   ngOnInit() {
     this.gridSettings = { ...this.settings };
     delete this.gridSettings.query;
+    this.refreshService.refresh$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((event) => {
+        if (
+          event.type === 'record-updated' ||
+          event.type === 'record-created' ||
+          event.type === 'widget-refresh'
+        ) {
+          if (
+            !event.data?.resourceId ||
+            event.data.resourceId === this.settings.resource
+          ) {
+            if (this.coreGridComponent) {
+              this.coreGridComponent.reloadData();
+            }
+            if (this.aggregationGridComponent) {
+              this.aggregationGridComponent.reloadData();
+            }
+            if (this.referenceDataGridComponent) {
+              this.referenceDataGridComponent.reloadData();
+            }
+          }
+        }
+      });
     let buildSortFields = false;
     if (this.settings.resource) {
       this.useReferenceData = false;

--- a/libs/shared/src/lib/services/refresh/refresh.service.spec.ts
+++ b/libs/shared/src/lib/services/refresh/refresh.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RefreshService } from './refresh.service';
+
+describe('RefreshService', () => {
+  let service: RefreshService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RefreshService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/shared/src/lib/services/refresh/refresh.service.ts
+++ b/libs/shared/src/lib/services/refresh/refresh.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { Subject, Observable } from 'rxjs';
+
+/**
+ * Interface for refresh events
+ */
+export interface RefreshEvent {
+  type:
+    | 'record-updated'
+    | 'record-created'
+    | 'record-deleted'
+    | 'widget-refresh';
+  data?: {
+    formId?: string;
+    recordId?: string | string[];
+    resourceId?: string;
+  };
+}
+
+/**
+ * Shared refresh service to notify components when data needs to be refreshed
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class RefreshService {
+  /** Subject for refresh events */
+  private refreshSubject = new Subject<RefreshEvent>();
+
+  /** Observable for components to subscribe to */
+  public refresh$: Observable<RefreshEvent> =
+    this.refreshSubject.asObservable();
+
+  /**
+   * Trigger a refresh event
+   *
+   * @param type Type of refresh event
+   * @param data Optional data associated with the event
+   */
+  triggerRefresh(
+    type: RefreshEvent['type'],
+    data?: RefreshEvent['data']
+  ): void {
+    this.refreshSubject.next({ type, data });
+  }
+
+  /**
+   * Trigger a record update refresh
+   *
+   * @param formId Form ID
+   * @param recordId Record ID(s)
+   * @param resourceId Optional resource ID
+   */
+  triggerRecordUpdate(
+    formId?: string,
+    recordId?: string | string[],
+    resourceId?: string
+  ): void {
+    this.triggerRefresh('record-updated', { formId, recordId, resourceId });
+  }
+
+  /**
+   * Trigger a record creation refresh
+   *
+   * @param formId Form ID
+   * @param recordId Record ID
+   * @param resourceId Optional resource ID
+   */
+  triggerRecordCreated(
+    formId?: string,
+    recordId?: string,
+    resourceId?: string
+  ): void {
+    this.triggerRefresh('record-created', { formId, recordId, resourceId });
+  }
+
+  /**
+   * Trigger a widget refresh
+   */
+  triggerWidgetRefresh(): void {
+    this.triggerRefresh('widget-refresh');
+  }
+}


### PR DESCRIPTION
# Description

Implemented automatic widget refresh functionality so that dashboard widgets and grids update immediately after a form is saved, without requiring users to manually refresh the page.

## Useful links

- **Ticket**: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2fbd463fd8c4805faabbe7bfbea5a28a&pm=s&pvs=31

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test A:**
- Navigate to dashboard with grid widgets
- Create a new record (NF) and fill it
- Verify progress bar automatically updates after modal closes without page refresh

## Screenshots

N/A

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
