### PR TITLE
MAB-695 For some matrix dynamic where dropdowns are linked, the row doesn’t update value when needed

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -446,6 +446,21 @@ const initChoices = (
           options.question === question &&
           options.columnName === foreignColName
         ) {
+          const targetColName = column.name;
+          if (
+            options.row &&
+            options.row.value[targetColName] !== undefined &&
+            options.row.value[targetColName] !== null
+          ) {
+            options.row.value[targetColName] = null;
+
+            // Update the cell question if it exists
+            const cellKey = `${options.row.rowName}:${targetColName}`;
+            const matrixCell = question.cells?.get(cellKey);
+            if (matrixCell && matrixCell.question) {
+              matrixCell.question.value = null;
+            }
+          }
           updateChoices(referenceDataService, question, column);
         }
       });

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -447,11 +447,7 @@ const initChoices = (
           options.columnName === foreignColName
         ) {
           const targetColName = column.name;
-          if (
-            options.row &&
-            options.row.value[targetColName] !== undefined &&
-            options.row.value[targetColName] !== null
-          ) {
+          if (options.row && !isNil(options.row.value[targetColName])) {
             options.row.value[targetColName] = null;
 
             // Update the cell question if it exists


### PR DESCRIPTION
# Description

Fixed a bug in matrix dynamic questions where linked dropdowns (parent-child relationships) would retain stale values when the parent dropdown changed.

Problem: When a user

- Added a row in a matrix dynamic question with linked dropdowns (e.g., framework → target)
- Selected a value for the parent dropdown (framework)
- Selected a value for the dependent dropdown (target)
- Changed the parent dropdown value

The dependent dropdown would not clear its old value, even though new filtered choices were loaded. This allowed users to save forms with invalid dropdown combinations (e.g., a target that doesn't belong to the selected framework).

## Useful links

- **ticket**: https://www.notion.so/cb32a703a24e4e03a3ec47bd6b38c4a4?v=467317821cf24db6b43c59325335e46b&p=2ffd463fd8c4809692a9d7bea3b38012&pm=s

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Manual testing:**

- Create a form with a matrix dynamic question containing linked dropdowns (parent → child relationship)
- Add a row to the matrix
- Select a value for the parent dropdown (e.g., "Framework")
- Select a value for the dependent dropdown (e.g., "Target")
- Change the parent dropdown to a different value
- Expected result: The dependent dropdown should immediately clear and show only valid options for the new parent value
- Actual result (before fix): The old dependent value persisted even though the dropdown choices updated

## Screenshots

N/A

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
