### PR TITLE
MAB-726: Prevent User to change their own assigned country

### DIFF
--- a/libs/shared/src/lib/views/profile/profile.component.ts
+++ b/libs/shared/src/lib/views/profile/profile.component.ts
@@ -22,6 +22,7 @@ import { get } from 'lodash';
   styleUrls: ['./profile.component.scss'],
 })
 export class ProfileComponent extends UnsubscribeComponent implements OnInit {
+  private readonly restrictedSelfManagedAttributes = new Set(['country']);
   /** Current user */
   public user: any;
   /** Form to edit the user */
@@ -42,6 +43,8 @@ export class ProfileComponent extends UnsubscribeComponent implements OnInit {
     choices?: any[];
     valueField?: string;
     textField?: string;
+    referenceData?: string;
+    resource?: string;
   }[] = [];
 
   /**
@@ -192,42 +195,62 @@ export class ProfileComponent extends UnsubscribeComponent implements OnInit {
    * Get attributes from back-end, and set controls if any
    */
   private getAttributes(): void {
-    this.restService.get('/permissions/configuration').subscribe((config) => {
-      // can user edit attributes
-      const manualCreation = get(config, 'attributes.local', true);
-      this.restService
-        .get('/permissions/attributes')
-        .subscribe((attributes: any) => {
-          this.userForm.addControl(
-            'attributes',
-            this.fb.group(
-              attributes.reduce(
-                (group: any, attribute: any) => ({
-                  ...group,
-                  [attribute.value]: this.fb.control({
-                    value: get(
-                      this.user,
-                      `attributes.${attribute.value}`,
-                      null
-                    ),
-                    disabled: !manualCreation,
-                  }),
-                }),
-                {}
-              )
-            )
-          );
-          this.attributes = attributes.filter((x: any) => x.userCanEdit);
-          for (const attribute of attributes.filter(
-            (x: any) => x.userCanEdit
-          )) {
-            // Fetch reference data from attribute field
-            if (attribute.referenceData || attribute.resource) {
-              this.fetchAttributeChoices(attribute);
-            }
-          }
-        });
-    });
+    this.restService
+      .get('/permissions/configuration')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (config) => {
+          // can user edit attributes
+          const manualCreation = get(config, 'attributes.local', true);
+          this.restService
+            .get('/permissions/attributes')
+            .pipe(takeUntil(this.destroy$))
+            .subscribe({
+              next: (attributes: any) => {
+                this.userForm.addControl(
+                  'attributes',
+                  this.fb.group(
+                    attributes.reduce(
+                      (group: any, attribute: any) => ({
+                        ...group,
+                        [attribute.value]: this.fb.control({
+                          value: get(
+                            this.user,
+                            `attributes.${attribute.value}`,
+                            null
+                          ),
+                          disabled:
+                            !manualCreation ||
+                            this.restrictedSelfManagedAttributes.has(
+                              attribute.value
+                            ),
+                        }),
+                      }),
+                      {}
+                    )
+                  )
+                );
+                this.attributes = attributes.filter(
+                  (x: any) =>
+                    x.userCanEdit &&
+                    !this.restrictedSelfManagedAttributes.has(x.value)
+                );
+                for (const attribute of this.attributes) {
+                  // Fetch reference data from attribute field
+                  if (attribute.referenceData || attribute.resource) {
+                    this.fetchAttributeChoices(attribute);
+                  }
+                }
+              },
+              error: (err) => {
+                this.snackBar.openSnackBar(err.message, { error: true });
+              },
+            });
+        },
+        error: (err) => {
+          this.snackBar.openSnackBar(err.message, { error: true });
+        },
+      });
   }
 
   /**
@@ -239,8 +262,13 @@ export class ProfileComponent extends UnsubscribeComponent implements OnInit {
     this.restService
       .get(`/permissions/attributes/${attribute.value}/choices`)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((choices: any) => {
-        attribute.choices = choices;
+      .subscribe({
+        next: (choices: any) => {
+          attribute.choices = choices;
+        },
+        error: (err) => {
+          this.snackBar.openSnackBar(err.message, { error: true });
+        },
       });
   }
 }


### PR DESCRIPTION
# Description

The issue was that users could go into their own profile and change their assigned country, which then gave them access to BRs for that country, even though that assignment should only be managed by the MAB Secretariat. Fixed it mainly on the backend by updating the `editUserProfile` mutation so the `country` attribute is ignored unless the request is for another user and the person making the change has the `can_see_users` permission.

## Useful links

- https://www.notion.so/Prevent-User-to-change-their-own-assigned-country-310d463fd8c48007a827c135edb73e77?source=copy_link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules