### PR TITLE
MAB-731: Site profile edit page needs to have a 'Save' button in addition to 'Save and close'

### DIFF
--- a/libs/shared/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.html
@@ -138,11 +138,29 @@
 
       <!-- Regular save button when feature is disabled -->
       <ui-button
+        *ngIf="!survey.enableSaveAndSubmit && data.recordId"
+        category="secondary"
+        variant="primary"
+        [disabled]="saving || autosaving"
+        (click)="save()"
+      >
+        <span class="flex items-center whitespace-nowrap">
+          {{ 'common.save' | translate }}
+          <ui-spinner
+            *ngIf="saving && !autosaving"
+            [size]="'small'"
+            class="mr-1"
+          />
+        </span>
+      </ui-button>
+
+      <!-- Regular save & close button when feature is disabled -->
+      <ui-button
         *ngIf="!survey.enableSaveAndSubmit"
         category="secondary"
         variant="primary"
         [disabled]="saving || autosaving"
-        (click)="submit()"
+        (click)="submit(true)"
         cdkFocusInitial
       >
         <ng-container *ngIf="!autosaving">

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -188,6 +188,8 @@ export class FormModalComponent
   protected commentsLoaded = new EventEmitter();
   /** isSaveAndSubmitEnabled state */
   public isSaveAndSubmitEnabled = false;
+  /** Controls whether a successful regular save should close the modal */
+  private closeAfterRegularSave = true;
   /** Auto save interval */
   private autoSaveInterval?: Subscription;
   /** Stringified version of last saved survey data for autosave comparison */
@@ -608,9 +610,24 @@ export class FormModalComponent
   }
 
   /**
-   * Calls the complete method of the survey if no error (original submit for backward compatibility)
+   * Saves the form while keeping the modal open when using the regular save flow.
    */
-  public submit(): void {
+  public save(): void {
+    if (this.survey.enableSaveAndSubmit) {
+      this.survey.tryComplete();
+      return;
+    }
+
+    this.submit(false);
+  }
+
+  /**
+   * Calls the complete method of the survey if no error (original submit for backward compatibility)
+   *
+   * @param closeAfterSave whether the modal should close after a successful regular save
+   */
+  public submit(closeAfterSave = true): void {
+    this.closeAfterRegularSave = closeAfterSave;
     this.formHelpersService.validateAndSubmit(
       this.survey,
       {
@@ -969,7 +986,7 @@ export class FormModalComponent
             })
           );
           // Form doesn't use Save and Submit feature, close the dialog
-          if (!this.survey.enableSaveAndSubmit) {
+          if (!this.survey.enableSaveAndSubmit && this.closeAfterRegularSave) {
             this.closeDialog({
               template: this.form?.id,
               data: data[responseType],

--- a/libs/shared/src/lib/components/resource-modal/resource-modal.component.ts
+++ b/libs/shared/src/lib/components/resource-modal/resource-modal.component.ts
@@ -70,7 +70,8 @@ export class ResourceModalComponent extends FormModalComponent {
         .checkUniquePropriety(this.survey)
         .then(async (response: CheckUniqueProprietyReturnT) => {
           if (response.verified) {
-            this.loading = true;
+            this.saving = true;
+            this.survey.readOnly = true;
             await this.formHelpersService.uploadFiles(
               this.temporaryFilesStorage,
               this.form?.id


### PR DESCRIPTION
# Description

The issue was that when editing a Site Profile, the modal only showed a "Save and close" button. It is now updated so the shared form modal to also show a "Save" button during edit mode. Both buttons now use the same existing validation and save logic, but `Save` keeps the modal open while `Save and close` preserves the current behavior and closes it after a successful save.

## Useful links

- https://www.notion.so/Site-profile-edit-page-needs-to-have-a-Save-button-in-addition-to-Save-and-close-311d463fd8c4809c8fdaffbb579521be?source=copy_link

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules