### PR TITLE
MAB-741: Limit permissions to add roles to user

### DIFF
--- a/apps/back-office/src/app/app-preview/app-preview-routing.module.ts
+++ b/apps/back-office/src/app/app-preview/app-preview-routing.module.ts
@@ -39,6 +39,7 @@ const routes: Routes = [
                   import('../shared/pages/roles/roles.module').then(
                     (m) => m.RolesModule
                   ),
+                data: { inApplication: true },
                 // canActivate: [PermissionGuard]
               },
               {

--- a/apps/back-office/src/app/dashboard/pages/applications/applications.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/applications/applications.component.ts
@@ -394,7 +394,12 @@ export class ApplicationsComponent
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {
       if (value) {
-        this.previewService.setRole(value.role);
+        const roleId =
+          typeof value.role === 'string' ? value.role : value.role?.id || '';
+        if (!roleId) {
+          return;
+        }
+        this.previewService.setRole(roleId);
         this.router.navigate(['./app-preview', element.id]);
       }
     });

--- a/apps/back-office/src/app/graphql.module.ts
+++ b/apps/back-office/src/app/graphql.module.ts
@@ -38,8 +38,9 @@ export const createApollo = (httpLink: HttpLink): ApolloClientOptions<any> => {
   const ws = new GraphQLWsLink(
     createClient({
       url: `${environment.subscriptionApiUrl}/graphql`,
-      connectionParams: {
-        authToken: localStorage.getItem('idtoken'),
+      connectionParams: () => {
+        const authToken = localStorage.getItem('idtoken');
+        return authToken ? { authToken } : {};
       },
     })
   );

--- a/apps/front-office/src/app/graphql.module.ts
+++ b/apps/front-office/src/app/graphql.module.ts
@@ -38,8 +38,9 @@ export const createApollo = (httpLink: HttpLink): ApolloClientOptions<any> => {
   const ws = new GraphQLWsLink(
     createClient({
       url: `${environment.subscriptionApiUrl}/graphql`,
-      connectionParams: {
-        authToken: localStorage.getItem('idtoken'),
+      connectionParams: () => {
+        const authToken = localStorage.getItem('idtoken');
+        return authToken ? { authToken } : {};
       },
       on: {
         error: (err) => console.error('WebSocket Error', err),

--- a/libs/shared/src/lib/components/user-summary/graphql/queries.ts
+++ b/libs/shared/src/lib/components/user-summary/graphql/queries.ts
@@ -37,8 +37,12 @@ export const GET_APPLICATIONS = gql`
 
 /** Get Roles query */
 export const GET_ROLES = gql`
-  query GetRoles($application: ID) {
-    roles(application: $application) {
+  query GetRoles($application: ID, $forUserAssignment: Boolean, $asRole: ID) {
+    roles(
+      application: $application
+      forUserAssignment: $forUserAssignment
+      asRole: $asRole
+    ) {
       id
       title
     }

--- a/libs/shared/src/lib/components/user-summary/user-roles/user-app-roles/user-app-roles.component.ts
+++ b/libs/shared/src/lib/components/user-summary/user-roles/user-app-roles/user-app-roles.component.ts
@@ -11,6 +11,7 @@ import { GET_APPLICATIONS, GET_ROLES } from '../../graphql/queries';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
 import { SnackbarService } from '@oort-front/ui';
+import { ApplicationService } from '../../../../services/application/application.service';
 
 /** Roles tab for the user summary */
 @Component({
@@ -55,11 +56,13 @@ export class UserAppRolesComponent
    * @param fb Angular form builder
    * @param apollo Apollo client
    * @param snackBar Shared snackbar service
+   * @param applicationService Shared application service
    */
   constructor(
     private fb: FormBuilder,
     private apollo: Apollo,
-    private snackBar: SnackbarService
+    private snackBar: SnackbarService,
+    private applicationService: ApplicationService
   ) {
     super();
   }
@@ -145,6 +148,8 @@ export class UserAppRolesComponent
         query: GET_ROLES,
         variables: {
           application,
+          forUserAssignment: true,
+          asRole: this.applicationService.asRole || null,
         },
       })
       .pipe(takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.html
+++ b/libs/shared/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.html
@@ -1,11 +1,11 @@
-<div class="flex flex-col">
+<div class="flex flex-col" *ngIf="canEdit && availableGroups.length > 0">
   <h2>{{ 'common.group.few' | translate }}</h2>
   <div uiFormFieldDirective>
     <label>
       {{ 'components.user.summary.roles.selectedGroups' | translate }}</label
     >
     <ui-select-menu [formControl]="selectedGroups" [multiselect]="true">
-      <ui-select-option *ngFor="let group of groups" [value]="group.id">
+      <ui-select-option *ngFor="let group of availableGroups" [value]="group.id">
         {{ group.title }}
       </ui-select-option>
     </ui-select-menu>

--- a/libs/shared/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.ts
+++ b/libs/shared/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.ts
@@ -19,6 +19,8 @@ import { SnackbarService } from '@oort-front/ui';
 export class UserGroupsComponent implements OnInit {
   /** Groups */
   public groups: Group[] = [];
+  /** Groups that can be rendered in the dropdown */
+  public availableGroups: Group[] = [];
   /** User */
   @Input() user!: User;
   /** Selected groups */
@@ -65,7 +67,19 @@ export class UserGroupsComponent implements OnInit {
       .subscribe({
         next: ({ data, loading }) => {
           if (data) {
-            this.groups = data.groups;
+            this.groups = data.groups || [];
+            this.availableGroups = this.groups.filter(
+              (group) => !!group?.id && !!group?.title
+            );
+
+            const selectedGroupIds = (this.selectedGroups?.value || []).filter(
+              (groupId: string | undefined) =>
+                typeof groupId === 'string' &&
+                this.availableGroups.some((group) => group.id === groupId)
+            );
+            this.selectedGroups?.setValue(selectedGroupIds, {
+              emitEvent: false,
+            });
           }
           this.loading = loading;
         },

--- a/libs/shared/src/lib/components/user-summary/user-roles/user-roles.component.html
+++ b/libs/shared/src/lib/components/user-summary/user-roles/user-roles.component.html
@@ -1,5 +1,5 @@
 <shared-user-groups
-  *ngIf="canSeeGroups"
+  *ngIf="canSeeGroups && !application"
   [canEdit]="!application"
   [user]="user"
   (edit)="edit.emit($event)"

--- a/libs/shared/src/lib/services/application/application.service.ts
+++ b/libs/shared/src/lib/services/application/application.service.ts
@@ -125,6 +125,9 @@ import { GraphQLError } from 'graphql';
   providedIn: 'root',
 })
 export class ApplicationService {
+  /** Role used to load application in preview mode */
+  public asRole = '';
+
   /** Current application */
   public application = new BehaviorSubject<Application | null>(null);
 
@@ -247,6 +250,7 @@ export class ApplicationService {
     if (this.application.getValue()) {
       this.leaveApplication();
     }
+    this.asRole = asRole || '';
     // Then, open the new application
     this.applicationSubscription = this.apollo
       .query<ApplicationQueryResponse>({
@@ -337,6 +341,7 @@ export class ApplicationService {
     }
     const application = this.application.getValue();
     this.application.next(null);
+    this.asRole = '';
     this.applicationSubscription?.unsubscribe();
     this.notificationSubscription?.unsubscribe();
     this.lockSubscription?.unsubscribe();

--- a/libs/shared/src/lib/views/application-users/application-users.component.html
+++ b/libs/shared/src/lib/views/application-users/application-users.component.html
@@ -31,6 +31,7 @@
         icon="send"
         category="secondary"
         variant="primary"
+        [disabled]="roles.length === 0"
         (click)="onInvite()"
       >
         {{ 'components.users.invite.confirm' | translate }}

--- a/libs/shared/src/lib/views/application-users/application-users.component.ts
+++ b/libs/shared/src/lib/views/application-users/application-users.component.ts
@@ -5,10 +5,15 @@ import { Apollo } from 'apollo-angular';
 import { Subject, takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../../components/utils/unsubscribe/unsubscribe.component';
 import { PositionAttributeCategory } from '../../models/position-attribute-category.model';
-import { AddUsersMutationResponse, Role } from '../../models/user.model';
+import {
+  AddUsersMutationResponse,
+  Role,
+  RolesQueryResponse,
+} from '../../models/user.model';
 import { ApplicationService } from '../../services/application/application.service';
 import { UserListComponent } from './components/user-list/user-list.component';
 import { ADD_USERS } from './graphql/mutations';
+import { GET_ASSIGNABLE_ROLES } from './graphql/queries';
 import { SnackbarService } from '@oort-front/ui';
 import { CompositeFilterDescriptor } from '@progress/kendo-data-query';
 import { RestService } from '../../services/rest/rest.service';
@@ -66,9 +71,9 @@ export class ApplicationUsersComponent
       .pipe(takeUntil(this.destroy$))
       .subscribe((application) => {
         if (application) {
-          this.roles = application.roles || [];
           this.positionAttributeCategories =
             application.positionAttributeCategories || [];
+          this.fetchAssignableRoles(application.id || '');
         }
       });
 
@@ -160,5 +165,36 @@ export class ApplicationUsersComponent
         .map((x) => x.id || '')
         .filter((x) => x !== '') || []
     );
+  }
+
+  /**
+   * Fetches roles that can be assigned by the current user.
+   *
+   * @param applicationId The application id
+   */
+  private fetchAssignableRoles(applicationId: string): void {
+    if (!applicationId) {
+      this.roles = [];
+      return;
+    }
+
+    this.apollo
+      .query<RolesQueryResponse>({
+        query: GET_ASSIGNABLE_ROLES,
+        variables: {
+          application: applicationId,
+          forUserAssignment: true,
+          asRole: this.applicationService.asRole || null,
+        },
+      })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: ({ data }) => {
+          this.roles = data?.roles || [];
+        },
+        error: (err) => {
+          this.snackBar.openSnackBar(err.message, { error: true });
+        },
+      });
   }
 }

--- a/libs/shared/src/lib/views/application-users/graphql/queries.ts
+++ b/libs/shared/src/lib/views/application-users/graphql/queries.ts
@@ -39,3 +39,25 @@ export const GET_APPLICATION_USERS = gql`
     }
   }
 `;
+
+/** Query to fetch roles visible for user assignment in an application */
+export const GET_ASSIGNABLE_ROLES = gql`
+  query GetAssignableRoles(
+    $application: ID!
+    $forUserAssignment: Boolean
+    $asRole: ID
+  ) {
+    roles(
+      application: $application
+      forUserAssignment: $forUserAssignment
+      asRole: $asRole
+    ) {
+      id
+      title
+      application {
+        id
+        name
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Description

The bug was that users could still see wrong role options in the UI. It is now fixed by filtering assignable roles server-side based on can_see_users and can_add_users.<id>, passing preview role context correctly, and updating user edit/invite screens to use that filtered list. Also hid the Groups section when it has no usable options.

## Useful links

- https://www.notion.so/Limit-permissions-to-add-roles-to-user-314d463fd8c480899102c07160f11727?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules