### PR TITLE
MAB-728: Improve role invite permission

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/users/graphql/queries.ts
+++ b/apps/back-office/src/app/dashboard/pages/users/graphql/queries.ts
@@ -18,6 +18,19 @@ export const GET_ROLES = gql`
   }
 `;
 
+/** Graphql query for getting roles the current user can assign */
+export const GET_ASSIGNABLE_ROLES = gql`
+  query GetAssignableRoles($application: ID) {
+    assignableRoles(application: $application) {
+      id
+      title
+      application {
+        name
+      }
+    }
+  }
+`;
+
 /** Graphql query for getting users */
 export const GET_USERS = gql`
   query GetUsers($first: Int, $afterCursor: ID, $filter: JSON) {

--- a/apps/back-office/src/app/dashboard/pages/users/users.component.html
+++ b/apps/back-office/src/app/dashboard/pages/users/users.component.html
@@ -41,6 +41,7 @@
         <button uiMenuItem (click)="onExport('xlsx')">.xlsx</button>
       </ui-menu>
       <ui-button
+        *ngIf="assignableRoles.length > 0"
         icon="send"
         category="secondary"
         variant="primary"

--- a/apps/back-office/src/app/dashboard/pages/users/users.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/users/users.component.ts
@@ -1,9 +1,10 @@
 import { Apollo, QueryRef } from 'apollo-angular';
 import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { GET_USERS, GET_ROLES } from './graphql/queries';
+import { GET_USERS, GET_ROLES, GET_ASSIGNABLE_ROLES } from './graphql/queries';
 import { ADD_USERS, DELETE_USERS } from './graphql/mutations';
 import {
   AddUsersMutationResponse,
+  AssignableRolesQueryResponse,
   ConfirmService,
   DeleteUsersMutationResponse,
   DownloadService,
@@ -55,6 +56,8 @@ export class UsersComponent extends UnsubscribeComponent implements OnInit {
   public users = new Array<User>();
   /** Back-office roles */
   public roles: Role[] = [];
+  /** Roles the current user can assign when inviting */
+  public assignableRoles: Role[] = [];
   /** User attributes */
   public attributes: any[] = [];
   /** Attribute choices for reference data */
@@ -127,6 +130,13 @@ export class UsersComponent extends UnsubscribeComponent implements OnInit {
         this.roles = data.roles;
         this.loading = loading;
       });
+    this.apollo
+      .watchQuery<AssignableRolesQueryResponse>({
+        query: GET_ASSIGNABLE_ROLES,
+      })
+      .valueChanges.subscribe(({ data }) => {
+        this.assignableRoles = data.assignableRoles;
+      });
 
     // Fetch user attributes configuration
     this.restService
@@ -169,7 +179,7 @@ export class UsersComponent extends UnsubscribeComponent implements OnInit {
     const { InviteUsersModalComponent } = await import('@oort-front/shared');
     const dialogRef = this.dialog.open(InviteUsersModalComponent, {
       data: {
-        roles: this.roles,
+        roles: this.assignableRoles,
         users: this.users,
         downloadPath: 'download/invite',
         uploadPath: 'upload/invite',

--- a/libs/shared/src/lib/models/user.model.ts
+++ b/libs/shared/src/lib/models/user.model.ts
@@ -124,6 +124,11 @@ export interface RolesQueryResponse {
   roles: Role[];
 }
 
+/** Model for assignable roles graphql query response */
+export interface AssignableRolesQueryResponse {
+  assignableRoles: Role[];
+}
+
 /** Model for roles from applications graphql query response */
 export interface RolesFromApplicationsQueryResponse {
   rolesFromApplications: Role[];

--- a/libs/shared/src/lib/views/application-users/application-users.component.html
+++ b/libs/shared/src/lib/views/application-users/application-users.component.html
@@ -28,6 +28,7 @@
         <button uiMenuItem (click)="onExport('xlsx')">.xlsx</button>
       </ui-menu>
       <ui-button
+        *ngIf="assignableRoles.length > 0"
         icon="send"
         category="secondary"
         variant="primary"

--- a/libs/shared/src/lib/views/application-users/application-users.component.ts
+++ b/libs/shared/src/lib/views/application-users/application-users.component.ts
@@ -5,10 +5,15 @@ import { Apollo } from 'apollo-angular';
 import { Subject, takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../../components/utils/unsubscribe/unsubscribe.component';
 import { PositionAttributeCategory } from '../../models/position-attribute-category.model';
-import { AddUsersMutationResponse, Role } from '../../models/user.model';
+import {
+  AddUsersMutationResponse,
+  AssignableRolesQueryResponse,
+  Role,
+} from '../../models/user.model';
 import { ApplicationService } from '../../services/application/application.service';
 import { UserListComponent } from './components/user-list/user-list.component';
 import { ADD_USERS } from './graphql/mutations';
+import { GET_ASSIGNABLE_ROLES } from './graphql/queries';
 import { SnackbarService } from '@oort-front/ui';
 import { CompositeFilterDescriptor } from '@progress/kendo-data-query';
 import { RestService } from '../../services/rest/rest.service';
@@ -29,6 +34,8 @@ export class ApplicationUsersComponent
   public loading = true;
   /** Roles */
   public roles: Role[] = [];
+  /** Roles the current user can assign when inviting */
+  public assignableRoles: Role[] = [];
   /** Position attribute categories */
   public positionAttributeCategories: PositionAttributeCategory[] = [];
   /** User attributes */
@@ -69,6 +76,16 @@ export class ApplicationUsersComponent
           this.roles = application.roles || [];
           this.positionAttributeCategories =
             application.positionAttributeCategories || [];
+          // Fetch roles the current user can assign for this application
+          this.apollo
+            .watchQuery<AssignableRolesQueryResponse>({
+              query: GET_ASSIGNABLE_ROLES,
+              variables: { application: application.id },
+            })
+            .valueChanges.pipe(takeUntil(this.destroy$))
+            .subscribe(({ data }) => {
+              this.assignableRoles = data.assignableRoles;
+            });
         }
       });
 
@@ -90,7 +107,7 @@ export class ApplicationUsersComponent
     );
     const dialogRef = this.dialog.open(InviteUsersModalComponent, {
       data: {
-        roles: this.roles,
+        roles: this.assignableRoles,
         downloadPath: this.applicationService
           ? this.applicationService.usersDownloadPath
           : 'download/invite',

--- a/libs/shared/src/lib/views/application-users/graphql/queries.ts
+++ b/libs/shared/src/lib/views/application-users/graphql/queries.ts
@@ -1,5 +1,15 @@
 import { gql } from 'apollo-angular';
 
+/** Graphql query for getting roles the current user can assign */
+export const GET_ASSIGNABLE_ROLES = gql`
+  query GetAssignableRoles($application: ID) {
+    assignableRoles(application: $application) {
+      id
+      title
+    }
+  }
+`;
+
 /** Application users query */
 export const GET_APPLICATION_USERS = gql`
   query GetApplicationUsers(


### PR DESCRIPTION
# Description

When inviting users, the role dropdown showed all available roles regardless of the inviting user's permissions, meaning any user with invite access could assign roles they shouldn't be able to. Added a new assignableRoles GraphQL query on the backend that filters the role list based on the user's permissions: users with can_see_users still see all roles, but others only see roles they've been explicitly authorized to assign. The invite button is hidden entirely when the user has no assignable roles.

## Useful links

- https://www.notion.so/Improve-role-invite-permission-311d463fd8c4803dab41cb04a63b2b1f?source=copy_link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( \* == Mandatory )

- [X] - I have set myself as assignee of the pull request
- [X] - My code follows the style guidelines of this project
- [X] - Linting does not generate new warnings
- [X] - I have performed a self-review of my own code
- [X] - I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] - I have commented my code, particularly in hard-to-understand areas
- [X] - I have put JSDoc comment in all required places
- [X] - My changes generate no new warnings
- [X] - I have included screenshots describing my changes if relevant
- [X] - I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules