### PR TITLE
MAB-780 section I is not included in the form progression

### DIFF
--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -99,26 +99,18 @@ export const transformSurveyData = (survey: SurveyModel) => {
     }
   });
   if (survey.showPercentageProgressBar) {
-    // Filter only required questions that are not read-only, have input, and are visible (including parent visibility)
-    const requiredQuestions = survey
+    // Count every answerable question that's not read-only and visible (parents included),
+    // so sections without required questions (e.g. Section I of the PR form) still contribute.
+    const progressQuestions = survey
       .getAllQuestions()
-      .filter(
-        (q) => q.isRequired && !q.readOnly && q.hasInput && isQuestionVisible(q)
-      );
+      .filter((q) => !q.readOnly && q.hasInput && isQuestionVisible(q));
 
-    console.log(
-      'Missing required questions: ',
-      requiredQuestions
-        .filter((question: Question) => question.isEmpty())
-        .map((q) => q.name)
-    );
-
-    if (requiredQuestions.length) {
+    if (progressQuestions.length) {
       data._progress =
-        (requiredQuestions.filter((question: Question) => !question.isEmpty())
+        (progressQuestions.filter((question: Question) => !question.isEmpty())
           .length *
           100) /
-        requiredQuestions.length;
+        progressQuestions.length;
     }
   }
   return data;

--- a/libs/shared/src/lib/survey/progress-bar/progress-bar.component.html
+++ b/libs/shared/src/lib/survey/progress-bar/progress-bar.component.html
@@ -1,7 +1,7 @@
 <span class="text-2xl font-bold">{{ title }}</span>
 <div
   class="flex bg-[#D5DADD] rounded-full h-4 my-4 mx-10"
-  *ngIf="currentPageRequiredQuestions.length > 0"
+  *ngIf="currentPageProgressQuestions.length > 0"
 >
   <div
     class="bg-primary-500 text-xs font-medium text-blue-100 text-center p-0.5 leading-none rounded-full transition-[width] duration-1000"

--- a/libs/shared/src/lib/survey/progress-bar/progress-bar.component.ts
+++ b/libs/shared/src/lib/survey/progress-bar/progress-bar.component.ts
@@ -15,8 +15,8 @@ import { getVisibleQuestions } from '../../services/form-builder/form-builder.se
 export class ProgressBarComponent implements OnInit {
   /** Current survey model */
   @Input() model!: SurveyModel;
-  /** Current page required questions */
-  public currentPageRequiredQuestions: Question[] = [];
+  /** Current page questions considered for progress */
+  public currentPageProgressQuestions: Question[] = [];
   /** Progress bar percentage value */
   public value = 0;
   /** Title shown above percentage */
@@ -32,9 +32,9 @@ export class ProgressBarComponent implements OnInit {
   ngOnInit() {
     this.title = this.model.data.form_and_br;
     const updateCurrentPageQuestions = () => {
-      this.currentPageRequiredQuestions = getVisibleQuestions(
+      this.currentPageProgressQuestions = getVisibleQuestions(
         this.model.currentPage.questions
-      ).filter((q) => q.isRequired && q.hasInput);
+      ).filter((q) => q.hasInput);
       this.updateValue();
     };
     updateCurrentPageQuestions();
@@ -51,12 +51,13 @@ export class ProgressBarComponent implements OnInit {
    * Updates percentage value
    */
   private updateValue() {
-    this.value =
-      (this.currentPageRequiredQuestions.filter(
-        (question: Question) => !question.isEmpty()
-      ).length *
-        100) /
-      this.currentPageRequiredQuestions.length;
+    this.value = this.currentPageProgressQuestions.length
+      ? (this.currentPageProgressQuestions.filter(
+          (question: Question) => !question.isEmpty()
+        ).length *
+          100) /
+        this.currentPageProgressQuestions.length
+      : 0;
 
     this.cdr.detectChanges();
   }


### PR DESCRIPTION
# Description

Fix the PR (Periodic Review) Form progress tracking so Section I is included. The per-page progress bar and the global form progression (_progress) previously filtered questions by isRequired; because Section I has no required questions, its page showed no progress bar and its answers were not counted toward the total percentage. The filter is relaxed to consider every visible, non-read-only, answerable question, so every section, including Section I, now displays a progress bar and contributes to the overall progression. Works identically when filling a new form and when editing an existing record, since both flows share the same progress logic.

## Useful links

- **Ticket:** https://www.notion.so/PR-Form-Section-I-Is-not-included-in-the-form-progression-33cd463fd8c48033bf89e3fc6d2abe57

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open a PR Form and navigate to Section I, a progress bar is visible above the page
- Fill answers in Section I, the Section I progress bar percentage updates in real time
- Check the total form progression (_progress) Section I answers increase the global percentage
- Repeat the above while editing an already created PR Form record, same behavior
- Verify other sections (A–H, J, …) still show their progress bars and update correctly
- Verify that dynamic panels added/removed in any section still trigger progress recalculation

## Screenshots

**Before:**
<img width="2544" height="1165" alt="Screenshot from 2026-04-18 15-18-16" src="https://github.com/user-attachments/assets/5428ce9c-50cb-456b-a532-8bc84222ab89" />

**After**
<img width="2544" height="1165" alt="Screenshot from 2026-04-18 15-20-15" src="https://github.com/user-attachments/assets/0f7d48b3-92e1-4807-8026-8deddb5396e7" />



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
